### PR TITLE
Bring main up to date with new dev/main CI flow

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -2,11 +2,18 @@ name: Build and Push Docker Image
 
 on:
   push:
+    branches:
+      - main
+      - dev
     tags:
       - 'v*'
+  pull_request:
+    branches:
+      - main
+      - dev
 
 jobs:
-  build-and-push:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -17,23 +24,31 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract version from tag
+      - name: Extract metadata
         id: meta
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+        uses: docker/metadata-action@v5
+        with:
+          images: crzykidd/service-tracker-dashboard
+          tags: |
+            type=ref,event=branch
+            type=ref,event=branch,suffix=-{{sha}}
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
-          tags: |
-            crzykidd/service-tracker-dashboard:${{ env.VERSION }}
-            crzykidd/service-tracker-dashboard:latest
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            APP_VERSION=${{ env.VERSION }}
+            APP_VERSION=${{ steps.meta.outputs.version }}
             GIT_COMMIT=${{ github.sha }}


### PR DESCRIPTION
## Summary
- Establishes the dev branch on this repo
- Rewrites the Docker Hub publish workflow to handle dev, main, v* tags, and PRs distinctly
- Preserves APP_VERSION/GIT_COMMIT build-args

## Tag scheme
| Event | Tags |
|---|---|
| Push to dev | :dev, :dev-<short-sha> |
| Push to main | :main, :main-<short-sha> |
| v* tag | :VERSION, :latest |
| PR | build-only, no push |

## Test plan
- [ ] PR build job runs and succeeds (this becomes the required status check)
- [ ] After merge, main's workflow file matches dev's
- [ ] Branch protection on main can then require the build check