### PR TITLE
Push of V0.6.1 into main

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,60 @@
+## vexp — Context-Aware AI Coding <!-- vexp v2.0.16 -->
+
+### MANDATORY: use vexp pipeline — do NOT grep or glob the codebase
+For every task — bug fixes, features, refactors, debugging:
+**call `run_pipeline` FIRST**. It executes context search + impact analysis +
+memory recall in a single call, returning compressed results.
+
+Do NOT use grep, glob, Bash, or cat to search/explore the codebase.
+vexp returns pre-indexed, graph-ranked context that is more relevant and
+uses fewer tokens than manual searching. Prefer `get_skeleton` over Read to
+inspect files (detail: minimal/standard/detailed, 70-90% token savings).
+Only use Read when you need exact raw content to edit a specific line.
+
+### Primary Tool
+- `run_pipeline` — **USE THIS FOR EVERYTHING**. Single call that runs
+  capsule + impact + memory server-side. Returns compressed results.
+  Auto-detects intent (debug/modify/refactor/explore) from your task.
+  Includes full file content for pivots.
+  Examples:
+  - `run_pipeline({ "task": "fix JWT validation bug" })` — auto-detect
+  - `run_pipeline({ "task": "refactor db layer", "preset": "refactor" })` — explicit
+  - `run_pipeline({ "task": "add auth", "observation": "using JWT" })` — save insight in same call
+
+### Other MCP tools (use only when run_pipeline is insufficient)
+- `get_skeleton` — **preferred over Read** for inspecting files (minimal/standard/detailed detail levels, 70-90% token savings)
+- `index_status` — indexing status and health check
+- `expand_vexp_ref` — expand V-REF hash placeholders in v2 compact output
+
+### Workflow
+1. `run_pipeline("your task")` — ALWAYS FIRST. Returns pivots + impact + memories in 1 call
+2. Need more detail on a file? Use `get_skeleton({ files: [...], detail: "detailed" })` — avoid Read unless editing
+3. Make targeted changes based on the context returned
+4. `run_pipeline` again ONLY if you need more context during implementation
+5. Do NOT chain multiple vexp calls — one `run_pipeline` replaces capsule + impact + memory + observation
+
+### Subagent / Explore / Plan mode
+- Subagents CAN and MUST call `run_pipeline` — always include the task description
+- The PreToolUse hook blocks Grep/Glob when vexp daemon is running
+- Do NOT spawn Agent(Explore) to freely search — call `run_pipeline` first,
+  then pass the returned context into the agent prompt if needed
+- Always: `run_pipeline` → get context → spawn agent with context
+
+### Smart Features (automatic — no action needed)
+- **Intent Detection**: auto-detects from your task keywords. "fix bug" → Debug, "refactor" → blast-radius, "add" → Modify
+- **Hybrid Search**: keyword + semantic + graph centrality ranking
+- **Session Memory**: auto-captures observations; memories auto-surfaced in results
+- **LSP Bridge**: VS Code captures type-resolved call edges
+- **Change Coupling**: co-changed files included as related context
+
+### Advanced Parameters
+- `preset: "debug"` — forces debug mode (capsule+tests+impact+memory)
+- `preset: "refactor"` — deep impact analysis (depth 5)
+- `max_tokens: 12000` — increase total budget for complex tasks
+- `include_tests: true` — include test files in results
+- `include_file_content: false` — omit full file content (lighter response)
+
+### Multi-Repo Workspaces
+`run_pipeline` auto-queries all indexed repos. Use `repos: ["alias"]` to scope.
+Use `index_status` to discover available repo aliases.
+<!-- /vexp -->

--- a/.claude/hooks/vexp-guard.sh
+++ b/.claude/hooks/vexp-guard.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# vexp-guard: block Grep/Glob when vexp daemon is running AND index is healthy.
+# Fast path: if socket file or healthy marker doesn't exist, allow immediately.
+# PID check: verify daemon process is alive (handles stale files after kill -9).
+VEXP_DIR="${CLAUDE_PROJECT_DIR:-.}/.vexp"
+SOCK="$VEXP_DIR/daemon.sock"
+HEALTHY="$VEXP_DIR/healthy"
+PID_FILE="$VEXP_DIR/daemon.pid"
+if [ -S "$SOCK" ] && [ -f "$HEALTHY" ] && [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE" 2>/dev/null)" 2>/dev/null; then
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"vexp daemon is running. Use run_pipeline instead of Grep/Glob."}}'
+else
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"vexp index not ready, allowing direct search fallback."}}'
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,7 +20,8 @@
       "Bash(curl -s http://localhost:8815/api/*)",
       "Bash(git config *)",
       "Bash(git add *)",
-      "Bash(git commit -m ' *)"
+      "Bash(git commit -m ' *)",
+      "mcp__vexp__run_pipeline"
     ],
     "additionalDirectories": [
       "C:\\projects\\service-tracker-dashboard\\alembic\\versions"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,5 +25,19 @@
     "additionalDirectories": [
       "C:\\projects\\service-tracker-dashboard\\alembic\\versions"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Grep|Glob|Regex",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/vexp-guard.sh",
+            "timeout": 3000
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,28 @@
+## vexp context tools <!-- vexp v2.0.16 -->
+
+**MANDATORY: use `run_pipeline` — do NOT grep, glob, or read files manually.**
+vexp returns pre-indexed, graph-ranked context in a single call.
+
+### Workflow
+1. `run_pipeline` with your task description — ALWAYS FIRST (replaces all other tools)
+2. Make targeted changes based on the context returned
+3. `run_pipeline` again only if you need more context
+
+### Available MCP tools
+- `run_pipeline` — **PRIMARY TOOL**. Runs capsule + impact + memory in 1 call.
+  Auto-detects intent. Includes file content. Example: `run_pipeline({ "task": "fix auth bug" })`
+- `get_skeleton` — compact file structure
+- `index_status` — indexing status
+- `expand_vexp_ref` — expand V-REF placeholders in v2 output
+
+### Agentic search
+- Do NOT use built-in file search, grep, or codebase indexing — always call `run_pipeline` first
+- If you spawn sub-agents or background tasks, pass them the context from `run_pipeline`
+  rather than letting them search the codebase independently
+
+### Smart Features
+Intent auto-detection, hybrid ranking, session memory, auto-expanding budget.
+
+### Multi-Repo
+`run_pipeline` auto-queries all indexed repos. Use `repos: ["alias"]` to scope. Run `index_status` to see aliases.
+<!-- /vexp -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,7 +345,8 @@ v0.2.0 through v0.2.12 released. Detailed notes not retained.
 
 Initial development releases v0.1.0 through v0.1.4.
 
-[Unreleased]: https://github.com/crzykidd/service-tracker-dashboard/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/crzykidd/service-tracker-dashboard/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/crzykidd/service-tracker-dashboard/releases/tag/v0.6.1
 [0.6.0]: https://github.com/crzykidd/service-tracker-dashboard/releases/tag/v0.6.0
 [0.5.0]: https://github.com/crzykidd/service-tracker-dashboard/releases/tag/v0.5.0
 [0.4.14]: https://github.com/crzykidd/service-tracker-dashboard/releases/tag/v0.4.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] — 2026-05-16
+
+UI overhaul, part 1: Tiled dashboard redesign, per-tile expand drawer,
+icon vocabulary shared across Tiled and Dashboard, inline CSS/JS
+extracted to shared static files, Compact tab-highlight fix.
+
+### Added
+
+- **Per-tile expand drawer on Tiled.** Clicking the chevron on any tile
+  drops a panel anchored to the tile (overlay, not inline reflow). Drawer
+  shows host, internal/external URLs with health status, Docker status and
+  image tag, networks, ports, exposure observations, and widget data.
+  Action row at the bottom has Edit, Delete, and (when Dozzle is
+  configured) a Tools popover with a Dozzle link.
+- **Pencil-icon edit affordance** on Tiled tiles (status icon row) and
+  Dashboard table Actions column. Both navigate to `/edit/<id>?ref=<path>`.
+- **Tabler Icons** (v3.34.0) loaded via cdnjs CDN. Outline set only.
+  Used for all new icons in this release.
+- **Tools popover in the Tiled drawer.** Seeded with the Dozzle link.
+  Renders only when at least one tool is available.
+
+### Changed
+
+- **Tiled dashboard tile redesign.** Host line removed from the tile
+  face (now in the drawer). Status area replaced with icon row:
+  `ti-home` (internal URL), `ti-world` (external URL),
+  `ti-brand-docker` (Docker), plus widget indicator, Dozzle, edit
+  pencil, and expand chevron. Colors: green 2xx, amber SSL/stale, red
+  non-2xx or bad, gray not-configured.
+- **Exposure badges** (Tiled, Dashboard, edit page) now use Tabler
+  icons `ti-lock` / `ti-key` instead of 🔒 / 🔑 emoji.
+- **Dashboard table status column** now uses icon-and-label pills
+  sharing the Tiled icon vocabulary (`ti-home`, `ti-world`,
+  `ti-brand-docker`).
+- **Dashboard Tools column** uses `ti-terminal-2` instead of the
+  Dozzle SVG image.
+- **Per-template inline CSS and JS extracted** to
+  `static/css/dashboard.css` and `static/js/dashboard.js`. All three
+  dashboard views now share these files. Hybrid Tailwind-utilities-
+  plus-custom-CSS approach formalized; no frontend build step.
+
+### Removed
+
+- **"Show Widgets" filter-bar toggle on Tiled.** Widget data is now
+  accessible via the per-tile expand drawer.
+
+### Fixed
+
+- **Compact tab failed to highlight** in the nav. The missing
+  `{% set active_tab = 'compact' %}` declaration has been added.
+
 ## [0.6.0] — 2026-05-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ through the web UI or directly via API.
 
 ## What It Does
 
-- Three dashboard views (table, tiled, compact). Tiled view shows each service as a tile with a per-tile expand drawer for full host, URL, Docker, network, port, exposure, and widget detail.
+- Three dashboard views (table, tiled, compact). Tiled view shows each service as a tile with a per-tile expand drawer for full host, URL, Docker, network, port, exposure, and widget detail. Icons use [Tabler Icons](https://tabler.io/icons) v3.34.0 (loaded via CDN).
 - **Dashboard view controls (v0.6.0+).** A `Group by` axis selector
   (`group` / `stack` / `host`) and a `Show URL-less` filter render
   above the service grid on all three views. State is URL-driven, so
@@ -68,6 +68,8 @@ through the web UI or directly via API.
 ---
 
 ## Screenshots
+
+<!-- TODO(v0.6.1): Screenshots below predate the v0.6.1 tile redesign (host line removed from tile face, icon-row status strip, expand drawer replacing inline widget data, Tabler icons replacing emoji badges). Refresh before next public announcement. -->
 
 | Main Dashboard | Tiled View | Compact View |
 |---|---|---|
@@ -323,9 +325,10 @@ indicating the current source.
 #### Badges and headless rendering
 
 Each tile (tiled view) and row (table view) renders up to three
-exposure badges showing the layer name, a 🔒 if TLS-terminated, and
-a 🔑 if auth is required. A `+N` overflow badge appears when a
-service is observed by more than three interpreters.
+exposure badges showing the layer name, a lock icon (`ti-lock`) if
+TLS-terminated, and a key icon (`ti-key`) if auth is required. A `+N`
+overflow badge appears when a service is observed by more than three
+interpreters.
 
 Services with no exposure observations **and** no URLs (manual,
 explicit, or synthesized) are considered "headless." Their tiles

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ through the web UI or directly via API.
 
 ## What It Does
 
-- Three dashboard views (table, tiled, compact). Tiled view is mobile-friendly.
+- Three dashboard views (table, tiled, compact). Tiled view shows each service as a tile with a per-tile expand drawer for full host, URL, Docker, network, port, exposure, and widget detail.
 - **Dashboard view controls (v0.6.0+).** A `Group by` axis selector
   (`group` / `stack` / `host`) and a `Show URL-less` filter render
   above the service grid on all three views. State is URL-driven, so
@@ -422,6 +422,7 @@ cached in the `widget_value` table. Retention: rolling 30 days
 - Nightly backups run shortly after midnight; old backups are pruned
   per `backup_days_to_keep`.
 - Version metadata is shown in `/settings`.
+- Tile drawers on the Tiled view are transient view state and not bookmarkable; full edit remains at `/edit/<id>` and is bookmarkable.
 
 ---
 

--- a/docs/FUTURE.md
+++ b/docs/FUTURE.md
@@ -1,0 +1,274 @@
+# Future Discussion Area
+
+This file holds design discussions that have been deliberately parked
+— ideas that came up during scoped work on another feature and were
+set aside rather than being either committed to or rejected.
+
+This is **not** a roadmap. Items here may ship in a future release,
+may be reconsidered and rejected, or may sit indefinitely. The PRD
+(`docs/PRD.md`) is the document of record for what STD does and what
+it is about to do. The CHANGELOG is the record of what shipped. This
+file is the record of what was thought about and set aside.
+
+Each entry should capture enough context that picking it up later
+doesn't require re-derivation from scratch. Include the date it was
+parked, the conversation context, the design as sketched, and the
+explicit reason for deferral.
+
+---
+
+## Tools as a first-class concept
+
+**Parked:** 2026-05-16, during v0.6.1 UI rework wrap-up.
+
+### Context
+
+v0.6.1 introduced a "Tools" button inside the Tiled expand drawer
+that currently exposes only the Dozzle link. The button is the
+visible seed of a broader Tools concept: each `ServiceEntry` could
+have one or more tool links surfaced to the operator (Dozzle today,
+Dockhand soon, and an unknown set later — Portainer, "jump to
+compose file," "open in IDE," etc.).
+
+Today, tools are hardcoded in two places:
+
+- The Dozzle URL pattern is built in templates from
+  `STD_DOZZLE_URL` (a single global config value, loaded from
+  `settings.yml` / env) plus `entry.container_id`.
+- The aspirational per-entry overrides `entry.dozzle_url_override`
+  and `entry.container_id_override` were referenced in the old
+  Tiled template but never existed on the model. Removed in v0.6.1.
+
+This works for one tool. It will not scale to three.
+
+### Sketched shape
+
+Tools become a configurable concept with a few attributes per tool
+definition:
+
+- **Name** — operator-facing label ("Dozzle", "Dockhand").
+- **Icon** — Tabler icon name, or a path/SVG reference.
+- **URL template** — a string with variable substitution slots
+  drawn from the `ServiceEntry` row. Initial variable set:
+  `{container_id}`, `{container_id_short}` (first 12 chars),
+  `{host}`, `{container_name}`, `{stack_name}`, `{image_name}`.
+- **Enabled** — global on/off so a tool can be defined-but-hidden
+  without deletion.
+- **Applies-when predicate** — optional. A tool may not apply to
+  every entry. Dozzle requires a container_id; some tools may
+  require an exposure observation, a specific stack, or a host
+  match. Keep this simple at first — a single predicate like "only
+  if container_id is set" or "always" — and extend if real demand
+  appears.
+
+Storage: a new table (`tool_definition`) or a new key in the
+existing `Setting` JSON store. Lean toward a real table once there
+are more than ~5 fields per tool; the `Setting` JSON store is fine
+for the initial small case but gets awkward when the operator wants
+to edit, reorder, and validate individual tools.
+
+Per-entry overrides: a `service_entry.tool_overrides` JSON column,
+keyed by tool name, holding any of the URL-template variables that
+should override the computed default. Use case: a homelab with one
+Dozzle per host needs `{dozzle_base_url}` to vary per entry. This
+is the proper-implementation of the aspirational override columns
+the v0.6.1 cleanup removed.
+
+Defaults: STD ships with a Dozzle tool defined by default, mapped
+to today's `STD_DOZZLE_URL` config on first run (a migration job).
+Operators add or disable from there.
+
+UI:
+
+- New settings tab ("Tools") for adding, editing, ordering,
+  enabling, and disabling tool definitions.
+- The Tiled drawer's Tools button renders the enabled, applicable
+  tools for the entry. Single tool — direct link. Multiple — a
+  small popover.
+- The Dashboard table's Tools column does the same (currently
+  hardcoded to Dozzle).
+- Per-entry overrides exposed on the edit drawer/page in an
+  "Advanced" section that's hidden by default.
+
+### Why parked
+
+v0.6.1 just shipped. v0.6.2 (edit drawer) and v0.6.3 (staleness +
+widget detach-on-delete) are committed. Designing a full Tools
+abstraction now would either delay those releases or compete with
+them for design attention. The current single-tool implementation
+is genuinely fine for one tool; it becomes a problem when the
+second tool (Dockhand) is added.
+
+Reconsider when: a second tool is concrete enough to need a URL
+pattern, OR the operator finds themselves wanting per-host Dozzle
+overrides. Whichever comes first.
+
+### Open questions for when picked up
+
+- Are tool definitions per-installation, or are there "system"
+  tools that ship with STD and user-added tools that the operator
+  manages? (My instinct: just user-managed, with defaults seeded
+  on first run. One concept is better than two.)
+- Should tools support actions that mutate state ("restart this
+  container") or are they strictly navigation links? Strong lean
+  toward strictly navigation. Mutation is a much bigger surface
+  (auth model, error handling, rate-limiting, audit), and a
+  homelab dashboard isn't where that belongs.
+- Per-tool authentication — if a tool URL requires an API key, does
+  STD store that and inject it, or does the operator handle auth
+  on the tool's own end? Strong lean toward the latter; STD is not
+  a credentials vault.
+
+---
+
+## Service identity and duplicate detection
+
+**Parked:** 2026-05-16, during v0.6.1 wrap-up. Design ongoing in
+conversation; full design captured here for posterity.
+
+### Context
+
+When a service moves between hosts, or gets renamed, today's
+`(host, container_name)` match key produces a duplicate row: the
+old deployment goes stale, the new one starts fresh and empty.
+Operator-curated state (group, sort_priority, widget config, manual
+URL overrides) lives on the stale row and has to be manually
+migrated or re-entered.
+
+The v0.6.3 widget detach-on-delete feature (planned) reduces the
+*cost* of mishandled moves by preserving widget config when the
+stale row is deleted. It does not reduce the *frequency* of
+mishandled moves — the operator still needs to notice the duplicate
+exists.
+
+### Sketched shape
+
+A **Duplicates** surface in Settings that lists candidate pairs of
+service entries STD thinks might be the same logical service.
+Computed on-demand when the operator opens the tab — no schema
+changes, no continuous background job.
+
+Candidate criteria — a pair `(row_A, row_B)` is a candidate if
+**one row is fresh** (last_api_update within 2h) **and one is
+stale** (older than 2h or null), AND any of:
+
+- Same primary exposure hostname.
+- Same `image_name` AND same normalized `container_name`
+  (lowercased, hyphens/underscores stripped — catches
+  `homeassistant` ↔ `home-assistant`).
+- Same `image_name` AND same `stack_name` on different hosts.
+- Same explicit URL (`internalurl` or `externalurl`) where source
+  is `ui_edit` or `explicit_label`.
+
+Static entries (`is_static = true`) excluded from both sides.
+
+**Resolution UI:** side-by-side comparison of the two rows. Three
+actions:
+
+- **Merge B → A** (where A is the fresh row): transfer
+  operator-curated fields from B to A where A's value is null,
+  delete B. Specifically: `group_id`, `sort_priority`,
+  `widget_id`, `image_icon` (if A's was auto-fetched and B's was
+  override), URLs where B's source is `ui_edit` and A's is
+  `synthesized`.
+- **These aren't the same** — record the dismissal in a new
+  `duplicate_dismissal` table so the pair stops being surfaced.
+- **Cancel** — close, decide later.
+
+**No auto-merge, ever.** Confidence high enough to bypass operator
+confirmation doesn't exist for this kind of operation. Cost of a
+wrong merge is exactly the data loss the feature is trying to
+prevent.
+
+**Surfacing:** Settings → Duplicates tab. No top-of-dashboard
+banner, no popup. Optionally a count badge on the Settings nav if
+discoverability proves a problem — but start without it.
+
+### Active-active false positive
+
+If the operator runs a service on two hosts (active-active) and one
+side fails (becomes stale), the heuristic will flag the pair as a
+candidate. This is technically a false positive but operationally
+useful — the operator wants to know one side died anyway. Cost is
+a "These aren't the same" click to dismiss, which is cheap.
+
+An explicit "intentionally replicated" mark on a row to suppress
+duplicate suggestions even when one side goes stale was considered
+and rejected as YAGNI until the false-positive volume actually
+proves annoying.
+
+### Why parked
+
+Slot: v0.7.0. The path to it is:
+
+- v0.6.1 — extraction + Tiled redesign (delivered)
+- v0.6.2 — edit drawer
+- v0.6.3 — staleness visualization + widget detach-on-delete
+- v0.7.0 — duplicate detection + resolution
+
+Each release in this sequence makes the next one easier or less
+necessary. Staleness teaches the operator which rows are problems;
+detach prevents data loss when they delete; duplicate detection
+finds related pairs proactively. The more ambitious service
+identity concept (computed column on every row, `group_by` axis
+treatment, move-aware API) is intentionally NOT in v0.7.0 — gated
+on whether manual duplicate resolution proves insufficient after
+living with it.
+
+### Open questions for when picked up
+
+- Single stale threshold (used for Docker pill yellow, row clock
+  icon, AND duplicate eligibility) vs. per-purpose thresholds.
+  Lean toward single threshold.
+- Cached badge count on Settings nav vs. no badge. Start without;
+  add if operator forgets to check.
+- Move-aware API endpoint (`/api/v1/move`) for orchestrator-driven
+  moves (Ansible, Dockhand) to pre-declare an intended migration.
+  Deferred even past v0.7.0; gated on the move workflow actually
+  existing.
+
+---
+
+## Soft-delete for service entries
+
+**Parked:** 2026-05-16. Considered as an alternative to the
+widget-detach feature; the simpler detach feature was preferred but
+soft-delete remains worth considering.
+
+### Context
+
+Deleting a `ServiceEntry` today is permanent. The v0.6.3 plan adds
+widget detach-on-delete, which preserves the most operationally
+expensive piece of state (widget config) but loses the rest
+(group, sort_priority, manual icon, edited URLs).
+
+### Sketched shape
+
+A deleted entry enters a soft-delete state for some window (30
+days?) before hard-deletion. Recoverable via a Settings UI in the
+meantime. Doesn't appear on dashboards, doesn't get health-checked,
+doesn't count toward duplicate-detection.
+
+Adds a `deleted_at` nullable column to `service_entry` and a
+background job (or eager check) to hard-delete after the window
+expires. Dashboards filter `deleted_at IS NULL` in their queries.
+
+### Why parked
+
+Solves a problem (data loss on accidental deletion) that the widget
+detach-on-delete feature mostly addresses for the painful case
+(widget config). The remaining loss (group, sort_priority, icon
+override, URL edits) is cheap to recreate.
+
+Reconsider if operator finds themselves wanting recovery of full
+service-entry state, not just widget config. May also be worth it
+purely as a "I deleted the wrong row" safety net, independent of
+the data-loss-on-move concern.
+
+---
+
+## Adding entries
+
+Append new sections at the bottom. When an item moves into a real
+release plan, remove it here and reference the PRD section that
+picks it up.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -26,9 +26,10 @@
 6. [Current State (v0.4.14)](#6-current-state-v0414)
 7. [v0.5.0 — Cleanup Release](#7-v050--cleanup-release)
 8. [v0.6.0 — Delivered](#8-v060--delivered)
-9. [Versioning, Branches, and Releases](#9-versioning-branches-and-releases)
-10. [Cross-Repo Coordination](#10-cross-repo-coordination)
-11. [Open Questions](#11-open-questions)
+9. [v0.6.1 — UI Rework Part 1 (Delivered)](#9-v061--ui-rework-part-1-delivered)
+10. [Versioning, Branches, and Releases](#10-versioning-branches-and-releases)
+11. [Cross-Repo Coordination](#11-cross-repo-coordination)
+12. [Open Questions](#12-open-questions)
 
 ---
 
@@ -671,7 +672,98 @@ no `internalurl` / `externalurl`:
 
 ---
 
-## 9. Versioning, Branches, and Releases
+## 9. v0.6.1 — UI Rework Part 1 (Delivered)
+
+Patch release shipped 2026-05-16. No schema, API, config, or backend
+changes. Templates and static files only.
+
+### 9.1 Goals
+
+Formalize the visual language across all three dashboard views, extract
+per-template CSS/JS into shared static files, and deliver the core Tiled
+redesign that replaces text pills with an icon vocabulary and adds an
+expand drawer for per-service detail.
+
+### 9.2 Extraction
+
+Per-template inline `<style>` and `<script>` blocks consolidated into:
+
+- `static/css/dashboard.css` — design tokens (CSS custom properties),
+  shared component classes: `.tile`, `.tile-drawer`, `.status-icon`,
+  `.status-pill`, `.exposure-badge`, `.drawer-*`, etc.
+- `static/js/dashboard.js` — shared behaviors: auto-refresh, group
+  collapse, view-control submit-on-change, filter-input (view-detected
+  via `data-view` on `<body>`), tile-click, drawer open/close, tools
+  popover, delete confirmation, `toggleGroup`, `copyToClipboard`.
+
+Tailwind CDN stays for layout utilities; custom CSS handles components.
+No frontend build step introduced.
+
+### 9.3 Icon vocabulary
+
+Tabler Icons (v3.34.0) loaded via cdnjs CDN. Outline set only.
+
+| Purpose | Icon |
+| ------- | ---- |
+| Internal URL health | `ti-home` |
+| External URL health | `ti-world` |
+| Docker status | `ti-brand-docker` |
+| Widget indicator | `ti-chart-line` |
+| Dozzle logs | `ti-terminal-2` |
+| Edit | `ti-edit` |
+| Delete | `ti-trash` |
+| Tools popover | `ti-tools` |
+| Expand/collapse | `ti-chevron-down` / `ti-chevron-up` |
+| TLS badge | `ti-lock` |
+| Auth badge | `ti-key` |
+
+Status colors: green `#22c55e` (ok), amber `#f59e0b` (warn/stale),
+red `#ef4444` (bad), gray `#6b7280` (not configured / static).
+
+### 9.4 Tiled redesign
+
+- Tile face: icon + container name + exposure badges + status icon row.
+  Host line removed from tile face; moved to drawer.
+- Status icon row (right-aligned): internal URL, external URL, Docker,
+  separator, widget indicator (if present), Dozzle (if configured),
+  edit pencil, expand chevron.
+- Tile-headless treatment unchanged: no click affordance or hover border
+  on tiles with no URL, no exposures, and no widget. Chevron still shown.
+- Expand drawer: absolutely-positioned overlay beneath the tile. Closes
+  on outside click or second chevron press. Only one drawer open at a
+  time. Contains: host, URLs with health status, Docker with image tag,
+  networks, ports, exposure observations, widget data grid. Action row:
+  Edit button, Delete button (JS `confirm()` / `prompt()` for static
+  entries), Tools popover (Dozzle link when available).
+
+### 9.5 Other view changes
+
+- **Dashboard table:** status pills updated to icon-and-label pairs
+  sharing the Tiled vocabulary. Edit column uses pencil icon.
+  Dozzle Tools column uses `ti-terminal-2`.
+- **Compact tab:** missing `active_tab = 'compact'` variable added;
+  tab now correctly highlights in the nav.
+- **Exposure badges** (all views): 🔒 / 🔑 emoji replaced with
+  `ti-lock` / `ti-key` Tabler icons.
+- **Widget toggle removed** from Tiled filter bar; widget data now
+  lives in the per-tile drawer.
+
+### 9.6 UI rework arc
+
+v0.6.1 is the first of a sequence leading to v0.7.0:
+
+- **v0.6.2 (next)** — Edit drawer, replacing the full-page edit
+  navigation. The drawer carries URL state (bookmarkable).
+- **v0.6.x as needed** — Settings page polish, mobile breakpoint
+  tuning, followups from v0.6.1 review.
+- **v0.7.0** — Cuts when the UI theme feels complete, not on a fixed
+  schedule.
+
+No backend, schema, or API changes are planned for this arc.
+
+---
+
+## 10. Versioning, Branches, and Releases
 
 - `main` is the default branch and the source of truth for releases.
 - All work happens on `dev`. PR `dev` → `main` when ready to release.
@@ -685,7 +777,7 @@ no `internalurl` / `externalurl`:
 
 ---
 
-## 10. Cross-Repo Coordination
+## 11. Cross-Repo Coordination
 
 This project is paired with
 [docker-api-notifier](https://github.com/crzykidd/docker-api-notifier).
@@ -718,7 +810,7 @@ here; the notifier follows.
 
 ---
 
-## 11. Open Questions
+## 12. Open Questions
 
 - **Widget retention granularity.** A flat 30-day window may be too
   much for some widgets and not enough for others. Per-widget

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -13,6 +13,7 @@
 | 0.3     | 2026-05-13 | v0.6.0 delivered. Removed /api/register compat shim. Added §5.3 (v0.6.0 schema additions: networks, exposed_ports, published_ports). §9 rewritten from "planned" to "delivered." Added §10 (v0.7.0 — interpreter / exposure synthesis, planned). |
 | 0.4     | 2026-05-13 | Exposure interpreter mechanism folded into v0.6.0 rather than shipping as a separate v0.7.0 release. §9 expanded with §§9.4–9.8 (wire contract, synthesizer, URL provenance, per-interpreter settings, badges + headless rendering). New §5.4 documents the v0.6.0 schema additions for the interpreter (`service_exposure`, two URL source columns on `service_entry`, `setting` table). §10 retired (no scoped features for the next release). |
 | 0.5     | 2026-05-14 | v0.6.0 released. The originally-planned v0.5.x (view controls + helper consolidation), v0.6.0 (compat shim removal + capture columns), and v0.7.0 (exposure interpreter) work shipped together as a single v0.6.0 release. Former §8 (v0.5.x planning) folded into the new §8 (Delivered in v0.6.0). §6.2 D2 marked Resolved in v0.6.0. Cross-repo coordination (now §10.2) collapsed the v0.3.2 / v0.4.0 notifier split into a single notifier v0.4.0 pairing. Later sections renumbered: §10/§11/§12 → §9/§10/§11. |
+| 0.6     | 2026-05-16 | v0.6.1 delivered. UI overhaul part 1: tiled drawer, Tabler Icons v3.34.0 icon vocabulary, per-template inline CSS/JS extracted to shared static files. §9 added. |
 
 ---
 

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -1,0 +1,502 @@
+/* ============================================================
+   Service Tracker Dashboard — shared component stylesheet
+   Hybrid boundary: Tailwind utilities for layout primitives;
+   this file owns component classes and design tokens.
+   ============================================================ */
+
+/* ── Design tokens ────────────────────────────────────────── */
+:root {
+  --color-bg-base:      #111827;
+  --color-bg-surface:   #1f2937;
+  --color-bg-raised:    #374151;
+  --color-border:       #374151;
+  --color-border-focus: #3b82f6;
+  --color-border-input: #4b5563;
+
+  --color-text-primary:   #f9fafb;
+  --color-text-secondary: #e5e7eb;
+  --color-text-muted:     #9ca3af;
+
+  --color-status-ok:   #22c55e;
+  --color-status-warn: #f59e0b;
+  --color-status-bad:  #ef4444;
+  --color-status-muted:#6b7280;
+  --color-status-blue: #60a5fa;
+
+  --color-accent:      #3b82f6;
+  --color-accent-dim:  rgba(59, 130, 246, 0.3);
+
+  --radius-tile:  6px;
+  --radius-badge: 3px;
+  --radius-input: 0.5rem;
+}
+
+/* ── Form inputs ──────────────────────────────────────────── */
+.input-clean {
+  background-color: var(--color-bg-surface);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border-input);
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-input);
+  font-size: 0.875rem;
+  width: 100%;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.input-clean::placeholder { color: var(--color-text-muted); }
+.input-clean:focus {
+  border-color: var(--color-border-focus);
+  box-shadow: 0 0 0 2px var(--color-accent-dim);
+  outline: none;
+}
+
+.form-input {
+  background-color: var(--color-bg-surface);
+  color: var(--color-text-secondary);
+  border: 1px solid #4a5568;
+  padding: 0.625rem 1rem;
+  border-radius: var(--radius-input);
+  font-size: 0.875rem;
+  width: 100%;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.form-input::placeholder { color: var(--color-text-muted); }
+.form-input:focus {
+  border-color: var(--color-border-focus);
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-accent-dim);
+}
+
+/* ── Exposure badges ──────────────────────────────────────── */
+.exposure-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  margin-top: 3px;
+}
+.exposure-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  background-color: var(--color-bg-raised);
+  color: #cbd5e1;
+  border-radius: var(--radius-badge);
+  padding: 1px 5px;
+  font-size: 0.65em;
+  font-weight: 500;
+  line-height: 1.3;
+  border: 1px solid var(--color-border-input);
+}
+.exposure-badge-icon { font-size: 0.85em; }
+.exposure-badge-overflow {
+  background-color: var(--color-bg-surface);
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+/* ── Group title (tiled) ──────────────────────────────────── */
+.group-title {
+  font-size: 1.4em;
+  color: var(--color-text-secondary);
+  margin-top: 25px;
+  margin-bottom: 12px;
+  padding-bottom: 5px;
+  border-bottom: 2px solid var(--color-border);
+}
+
+/* ── Tile grid ────────────────────────────────────────────── */
+.tile-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
+  gap: 10px;
+}
+
+/* ── Tile wrapper (anchors the drawer) ───────────────────── */
+.tile-wrapper {
+  position: relative;
+}
+
+/* ── Tile ─────────────────────────────────────────────────── */
+.tile {
+  display: flex;
+  align-items: center;
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-tile);
+  padding: 10px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  transition: box-shadow 0.2s ease-in-out, border-color 0.2s ease-in-out;
+  position: relative;
+  user-select: none;
+}
+.tile:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+  border-color: var(--color-accent);
+}
+
+/* Headless tile: no URL, no exposures, no widget — no hover cue */
+.tile.tile-headless { cursor: default; }
+.tile.tile-headless:hover {
+  border-color: var(--color-border);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+
+/* Tile with open drawer gets a blue border on top/left/right;
+   bottom corners squared so it flows into the drawer. */
+.tile.tile-open {
+  border-color: var(--color-accent);
+  border-bottom-color: var(--color-accent);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+/* ── Tile icon (32px) ─────────────────────────────────────── */
+.tile-icon {
+  flex-shrink: 0;
+  margin-right: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+}
+.tile-icon img {
+  max-width: 100%;
+  max-height: 100%;
+  border-radius: 4px;
+}
+.icon-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background-color: var(--color-bg-raised);
+  border-radius: 4px;
+  font-size: 18px;
+  color: var(--color-text-muted);
+}
+/* Larger placeholder used in dashboard table */
+.icon-placeholder-lg {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background-color: #3d3d3d;
+  border-radius: 4px;
+  font-size: 20px;
+  color: #9e9e9e;
+}
+
+/* ── Tile details column ──────────────────────────────────── */
+.tile-details {
+  flex-grow: 1;
+  margin-right: 8px;
+  overflow: hidden;
+}
+.container-name {
+  font-weight: 600;
+  color: var(--color-text-primary);
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.95em;
+}
+
+/* ── Status icon row (new tiled design) ───────────────────── */
+.tile-status-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.tile-status-row .status-icon {
+  font-size: 16px;
+  line-height: 1;
+  padding: 3px;
+  border-radius: 3px;
+  cursor: default;
+  transition: opacity 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+}
+.tile-status-row a.status-icon { cursor: pointer; }
+.tile-status-row a.status-icon:hover { opacity: 0.75; }
+.tile-status-row button.status-icon {
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+.tile-status-row button.status-icon:hover { opacity: 0.75; }
+
+/* Status colors */
+.status-icon-ok   { color: var(--color-status-ok); }
+.status-icon-warn { color: var(--color-status-warn); }
+.status-icon-bad  { color: var(--color-status-bad); }
+.status-icon-muted{ color: var(--color-status-muted); }
+.status-icon-blue { color: var(--color-status-blue); }
+
+/* 1px vertical separator between status and action icons */
+.icon-sep {
+  display: inline-block;
+  width: 1px;
+  height: 14px;
+  background-color: var(--color-border-input);
+  margin: 0 2px;
+  flex-shrink: 0;
+}
+
+/* Chevron button */
+.tile-chevron {
+  border: none;
+  background: none;
+  color: var(--color-text-muted);
+  font-size: 16px;
+  padding: 3px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  transition: color 0.15s ease;
+}
+.tile-chevron:hover { color: var(--color-text-secondary); }
+.tile-open .tile-chevron { color: var(--color-accent); }
+
+/* ── Tile drawer ──────────────────────────────────────────── */
+.tile-drawer {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: -1px;
+  right: -1px;
+  z-index: 100;
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-accent);
+  border-top: none;
+  border-bottom-left-radius: var(--radius-tile);
+  border-bottom-right-radius: var(--radius-tile);
+  padding: 10px 12px 12px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.5);
+  max-height: 60vh;
+  overflow-y: auto;
+}
+.tile-drawer.drawer-open { display: block; }
+
+/* Two-column info rows inside drawer */
+.drawer-row {
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  gap: 4px 8px;
+  padding: 3px 0;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+.drawer-label {
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  padding-top: 1px;
+  white-space: nowrap;
+}
+.drawer-value {
+  color: var(--color-text-secondary);
+  word-break: break-word;
+}
+.drawer-divider {
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: 8px 0;
+}
+
+/* Drawer action row */
+.drawer-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.drawer-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.78rem;
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: 1px solid currentColor;
+  background: none;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.drawer-btn-edit {
+  color: #facc15;
+  border-color: #facc15;
+}
+.drawer-btn-edit:hover {
+  background-color: #facc15;
+  color: #000;
+}
+.drawer-btn-delete {
+  color: var(--color-status-bad);
+  border-color: var(--color-status-bad);
+}
+.drawer-btn-delete:hover {
+  background-color: var(--color-status-bad);
+  color: #fff;
+}
+.drawer-tools-wrap {
+  position: relative;
+  margin-left: auto;
+}
+.drawer-btn-tools {
+  color: var(--color-text-muted);
+  border-color: var(--color-border-input);
+}
+.drawer-btn-tools:hover {
+  color: var(--color-text-secondary);
+  border-color: var(--color-text-muted);
+}
+.tools-dropdown {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  background-color: var(--color-bg-raised);
+  border: 1px solid var(--color-border-input);
+  border-radius: 4px;
+  min-width: 160px;
+  z-index: 110;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+.tools-dropdown.dropdown-open { display: block; }
+.tools-dropdown a {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  transition: background-color 0.15s ease;
+}
+.tools-dropdown a:hover { background-color: #4b5563; }
+
+/* Drawer widget mini-cards (mirrors tiled_dash widget-box grid) */
+.drawer-widget-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+  margin-top: 4px;
+}
+.drawer-widget-card {
+  background-color: var(--color-bg-raised);
+  border: 1px solid #4b5563;
+  border-radius: 4px;
+  padding: 4px 6px;
+  text-align: center;
+}
+.drawer-widget-label {
+  font-size: 0.6rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+}
+.drawer-widget-value {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  line-height: 1.2;
+}
+
+/* ── Legacy status buttons (still used on old parts) ──────── */
+.status-button {
+  display: inline-block;
+  vertical-align: middle;
+  border: none;
+  border-radius: 4px;
+  color: white;
+  text-decoration: none;
+  text-align: center;
+  transition: opacity 0.2s;
+  font-weight: 500;
+  box-sizing: border-box;
+}
+.status-button:hover { opacity: 0.85; }
+.status-button-good    { background-color: #16a34a; }
+.status-button-bad     { background-color: #dc2626; }
+.status-button-unknown { background-color: #6b7280; }
+.status-button-stale   { background-color: #f59e0b; color: #fff; }
+
+/* ── Dashboard table — status icon pills ─────────────────── */
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 7px;
+  border-radius: 4px;
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: #fff;
+  white-space: nowrap;
+}
+.status-pill i { font-size: 13px; line-height: 1; }
+.status-pill-green  { background-color: #16a34a; }
+.status-pill-red    { background-color: #dc2626; }
+.status-pill-yellow { background-color: #b45309; color: #fff; }
+.status-pill-gray   { background-color: #4b5563; }
+
+/* ── Dashboard table logo icon ───────────────────────────── */
+.logo-icon {
+  height: 40px;
+  max-width: 40px;
+  filter: drop-shadow(1px 1px 2px rgba(0, 0, 0, 0.5));
+  transition: transform 0.2s ease-in-out;
+}
+.logo-icon:hover { transform: scale(1.1); }
+
+/* ── Compact view tile ────────────────────────────────────── */
+.compact-tile {
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: background-color 0.2s ease-in-out;
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+}
+.compact-tile.group-header {
+  background-color: var(--color-bg-base);
+  border: 1px solid var(--color-border-input);
+  border-left: 4px solid var(--color-accent);
+  font-weight: 700;
+  font-size: 1rem;
+  color: #fff;
+  text-align: center;
+  justify-content: center;
+  grid-column: span 1 / span 1;
+}
+.compact-tile:hover { background-color: var(--color-bg-raised); }
+.compact-tile.group-header:hover { background-color: var(--color-bg-base); }
+.compact-tile img {
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+}
+.compact-tile .container-name {
+  font-weight: 600;
+  color: #fff;
+  font-size: 0.85rem;
+}
+.compact-tile .host-name {
+  font-size: 0.7rem;
+  color: #aaaaaa;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1,0 +1,296 @@
+/* ============================================================
+   Service Tracker Dashboard — shared JavaScript
+   Covers: auto-refresh, group-collapse, view-controls,
+   filter-input, tiled tile-click, tile drawers, tools popover,
+   dashboard group-toggle, clipboard copy.
+   ============================================================ */
+
+(function () {
+  'use strict';
+
+  /* ── Auto-refresh ─────────────────────────────────────── */
+  let secondsSinceRefresh = 0;
+  let refreshInterval = 60;
+
+  function initRefresh() {
+    const refreshLabel    = document.getElementById('refreshTimer');
+    const refreshDropdown = document.getElementById('refreshInterval');
+    const saved = localStorage.getItem('refreshInterval');
+    if (saved !== null) {
+      refreshInterval = parseInt(saved, 10);
+      if (refreshDropdown) refreshDropdown.value = saved;
+    }
+    if (refreshDropdown) {
+      refreshDropdown.addEventListener('change', function () {
+        refreshInterval = parseInt(this.value, 10);
+        localStorage.setItem('refreshInterval', this.value);
+      });
+    }
+    setInterval(() => {
+      secondsSinceRefresh++;
+      if (refreshLabel) {
+        const m = Math.floor(secondsSinceRefresh / 60);
+        const s = secondsSinceRefresh % 60;
+        refreshLabel.textContent = `Refreshed ${m > 0 ? m + 'm ' : ''}${s}s ago`;
+      }
+      if (refreshInterval > 0 && secondsSinceRefresh >= refreshInterval) {
+        window.location.reload();
+      }
+    }, 1000);
+  }
+
+  /* ── View-control submit-on-change ───────────────────── */
+  function initViewControls() {
+    document.querySelectorAll('.view-control').forEach(function (el) {
+      el.addEventListener('change', function () {
+        const params = new URLSearchParams(window.location.search);
+        const key = this.dataset.param;
+        const value = (this.type === 'checkbox') ? (this.checked ? 'true' : 'false') : this.value;
+        params.set(key, value);
+        window.location.search = params.toString();
+      });
+    });
+  }
+
+  /* ── Tiled: group-collapse persistence ───────────────── */
+  function initTiledGroupCollapse() {
+    document.querySelectorAll('.group-header').forEach(header => {
+      const groupName  = header.dataset.group;
+      const container  = document.querySelector(`[data-group-container="${groupName}"]`);
+      const icon       = header.querySelector('.toggle-icon');
+      if (!container) return;
+      const isCollapsed = localStorage.getItem(`groupCollapse:${groupName}`) === 'true';
+      if (isCollapsed) {
+        container.style.display = 'none';
+        if (icon) icon.textContent = '▸';
+      }
+      header.addEventListener('click', () => {
+        const collapsed = container.style.display === 'none';
+        container.style.display = collapsed ? '' : 'none';
+        if (icon) icon.textContent = collapsed ? '▾' : '▸';
+        localStorage.setItem(`groupCollapse:${groupName}`, (!collapsed).toString());
+      });
+    });
+  }
+
+  /* ── Dashboard: group-collapse persistence ───────────── */
+  function initDashboardGroupCollapse() {
+    document.querySelectorAll('[id^="toggle-icon-"]').forEach(iconEl => {
+      const groupId = iconEl.id.replace('toggle-icon-', '');
+      const isCollapsed = localStorage.getItem(`group-collapsed-${groupId}`) === 'true';
+      const entries = document.querySelectorAll(`tr.group-entry[data-group-id='${groupId}']`);
+      entries.forEach(row => row.style.display = isCollapsed ? 'none' : '');
+      iconEl.textContent = isCollapsed ? '▶' : '▼';
+    });
+  }
+
+  /* ── Filter input (unified, view-detected) ───────────── */
+  function initFilter() {
+    const filterInput = document.getElementById('filterInput');
+    if (!filterInput) return;
+
+    const view = document.body.dataset.view;
+
+    filterInput.addEventListener('input', function () {
+      const filter = this.value.toLowerCase();
+
+      if (view === 'dashboard') {
+        document.querySelectorAll('table tbody tr[data-entry]').forEach(row => {
+          const group  = (row.dataset.group  || '').toLowerCase();
+          const name   = (row.dataset.container || '').toLowerCase();
+          const stack  = (row.dataset.stack  || '').toLowerCase();
+          row.style.display =
+            (group.includes(filter) || name.includes(filter) || stack.includes(filter)) ? '' : 'none';
+        });
+
+      } else if (view === 'compact') {
+        document.querySelectorAll('.compact-tile:not(.group-header)').forEach(tile => {
+          const name   = (tile.querySelector('.container-name')?.textContent || '').toLowerCase();
+          const host   = (tile.querySelector('.host-name')?.textContent      || '').toLowerCase();
+          const prev   = tile.previousElementSibling;
+          const grpTxt = (prev && prev.classList.contains('group-header'))
+                         ? prev.textContent.toLowerCase() : '';
+          tile.style.display = (name.includes(filter) || host.includes(filter) || grpTxt.includes(filter)) ? '' : 'none';
+        });
+
+      } else {
+        // tiled (default)
+        document.querySelectorAll('.tile-wrapper').forEach(wrapper => {
+          const name   = (wrapper.querySelector('.container-name')?.textContent || '').toLowerCase();
+          const grpCon = wrapper.closest('[data-group-container]');
+          const grpTxt = grpCon?.previousElementSibling?.textContent?.toLowerCase() || '';
+          wrapper.style.display = (name.includes(filter) || grpTxt.includes(filter)) ? '' : 'none';
+        });
+      }
+    });
+  }
+
+  /* ── Tiled: tile-body click → open URL ───────────────── */
+  function initTileClick() {
+    document.querySelectorAll('.tile').forEach(tile => {
+      const internalUrl = tile.dataset.internalurl;
+      const externalUrl = tile.dataset.externalurl;
+      if (!internalUrl && !externalUrl) return;
+      tile.style.cursor = 'pointer';
+      tile.addEventListener('click', function (event) {
+        // Don't fire if clicking an interactive child
+        if (event.target.closest('a, button')) return;
+        window.open(internalUrl || externalUrl, '_blank');
+      });
+    });
+  }
+
+  /* ── Tiled: expand drawer ────────────────────────────── */
+  let currentOpenDrawer = null;
+  let currentOpenTile   = null;
+
+  function closeCurrentDrawer() {
+    if (currentOpenDrawer) {
+      currentOpenDrawer.classList.remove('drawer-open');
+      currentOpenTile.classList.remove('tile-open');
+      const chevron = currentOpenTile.querySelector('.tile-chevron');
+      if (chevron) {
+        chevron.querySelector('i').className = 'ti ti-chevron-down';
+        chevron.setAttribute('aria-expanded', 'false');
+      }
+      currentOpenDrawer = null;
+      currentOpenTile   = null;
+    }
+  }
+
+  function initDrawers() {
+    document.querySelectorAll('.tile-chevron').forEach(btn => {
+      btn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        const wrapper = this.closest('.tile-wrapper');
+        const tile    = wrapper.querySelector('.tile');
+        const drawerId = this.dataset.drawer;
+        const drawer  = document.getElementById(drawerId);
+        if (!drawer) return;
+
+        if (currentOpenDrawer === drawer) {
+          closeCurrentDrawer();
+          return;
+        }
+        closeCurrentDrawer();
+
+        drawer.classList.add('drawer-open');
+        tile.classList.add('tile-open');
+        this.querySelector('i').className = 'ti ti-chevron-up';
+        this.setAttribute('aria-expanded', 'true');
+        currentOpenDrawer = drawer;
+        currentOpenTile   = tile;
+      });
+    });
+
+    // Close on outside click
+    document.addEventListener('click', function (e) {
+      if (!currentOpenDrawer) return;
+      if (!e.target.closest('.tile-wrapper')) closeCurrentDrawer();
+    });
+  }
+
+  /* ── Tiled drawer: tools popover ────────────────────── */
+  function initToolsPopovers() {
+    document.querySelectorAll('.drawer-btn-tools').forEach(btn => {
+      btn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        const wrap    = this.closest('.drawer-tools-wrap');
+        const dropdown = wrap.querySelector('.tools-dropdown');
+        if (!dropdown) return;
+        const isOpen  = dropdown.classList.contains('dropdown-open');
+        // Close all other open dropdowns
+        document.querySelectorAll('.tools-dropdown.dropdown-open').forEach(d => d.classList.remove('dropdown-open'));
+        if (!isOpen) dropdown.classList.add('dropdown-open');
+      });
+    });
+
+    document.addEventListener('click', function (e) {
+      if (!e.target.closest('.drawer-tools-wrap')) {
+        document.querySelectorAll('.tools-dropdown.dropdown-open').forEach(d => d.classList.remove('dropdown-open'));
+      }
+    });
+  }
+
+  /* ── Tiled drawer: delete action ────────────────────── */
+  function initDrawerDelete() {
+    document.querySelectorAll('.drawer-btn-delete').forEach(btn => {
+      btn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        const entryId       = this.dataset.entryId;
+        const containerName = this.dataset.containerName;
+        const isStatic      = this.dataset.isStatic === 'true';
+
+        let confirmed = false;
+        if (isStatic) {
+          const typed = prompt(
+            `STATIC ENTRY: Type the container name to confirm deletion.\n\n` +
+            `Container: "${containerName}"\n\nThis cannot be undone.`
+          );
+          confirmed = (typed === containerName);
+        } else {
+          confirmed = confirm(`Delete "${containerName}"? This cannot be undone.`);
+        }
+
+        if (!confirmed) return;
+
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = `/edit/${entryId}`;
+
+        const addField = (name, value) => {
+          const input = document.createElement('input');
+          input.type  = 'hidden';
+          input.name  = name;
+          input.value = value;
+          form.appendChild(input);
+        };
+        addField('delete', '1');
+        addField('delete_confirmation', containerName);
+
+        document.body.appendChild(form);
+        form.submit();
+      });
+    });
+  }
+
+  /* ── Dashboard: toggleGroup ──────────────────────────── */
+  window.toggleGroup = function (groupId) {
+    const entries = document.querySelectorAll(`tr.group-entry[data-group-id='${groupId}']`);
+    const icon    = document.getElementById(`toggle-icon-${groupId}`);
+    const isCollapsed = localStorage.getItem(`group-collapsed-${groupId}`) === 'true';
+    const newState = !isCollapsed;
+    entries.forEach(row => row.style.display = newState ? 'none' : '');
+    if (icon) icon.textContent = newState ? '▶' : '▼';
+    localStorage.setItem(`group-collapsed-${groupId}`, newState);
+  };
+
+  /* ── Dashboard: clipboard copy ───────────────────────── */
+  window.copyToClipboard = function (text, el) {
+    navigator.clipboard.writeText(text).then(() => {
+      const original = el.innerHTML;
+      el.innerHTML = '<em>Copied!</em>';
+      setTimeout(() => { el.innerHTML = original; }, 1000);
+    });
+  };
+
+  /* ── Bootstrap ───────────────────────────────────────── */
+  document.addEventListener('DOMContentLoaded', function () {
+    initRefresh();
+    initViewControls();
+    initFilter();
+
+    const view = document.body.dataset.view;
+    if (view === 'tiled') {
+      initTiledGroupCollapse();
+      initTileClick();
+      initDrawers();
+      initToolsPopovers();
+      initDrawerDelete();
+    } else if (view === 'dashboard') {
+      initDashboardGroupCollapse();
+    }
+    // compact has no extra init beyond refresh/filter/view-controls
+  });
+
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,81 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Service Tracker Dashboard</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tabler-icons/3.34.0/tabler-icons.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
   <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
-  <style>
-    .input-clean {
-        background-color: #1f2937; /* Tailwind's gray-800 */
-        color: #e2e8f0; /* light text */
-        border: 1px solid #4b5563; /* gray-600 */
-        padding: 0.5rem 0.75rem;
-        border-radius: 0.5rem;
-        font-size: 0.875rem;
-        width: 100%;
-        transition: border-color 0.2s ease, box-shadow 0.2s ease;
-    }
-
-    .input-clean::placeholder {
-        color: #94a3b8; /* Tailwind's slate-400 */
-    }
-
-    .input-clean:focus {
-        border-color: #3b82f6; /* blue-500 */
-        box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
-        outline: none;
-    }
-    .form-input {
-      background-color: #1f2937;
-      color: #e2e8f0;
-      border: 1px solid #4a5568;
-      padding: 0.625rem 1rem;
-      border-radius: 0.5rem;
-      font-size: 0.875rem;
-      width: 100%;
-      transition: border-color 0.2s ease, box-shadow 0.2s ease;
-    }
-
-    .form-input::placeholder {
-      color: #94a3b8;
-    }
-
-    .form-input:focus {
-      border-color: #3b82f6;
-      outline: none;
-      box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
-    }
-    /* Exposure badges (v0.6.0). Small pill per ServiceExposure row.
-       Loaded in base.html so the partial works on every dashboard
-       template + the edit page. */
-    .exposure-badges {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 3px;
-      margin-top: 3px;
-    }
-    .exposure-badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 2px;
-      background-color: #374151;
-      color: #cbd5e1;
-      border-radius: 3px;
-      padding: 1px 5px;
-      font-size: 0.65em;
-      font-weight: 500;
-      line-height: 1.3;
-      border: 1px solid #4b5563;
-    }
-    .exposure-badge-icon { font-size: 0.85em; }
-    .exposure-badge-overflow {
-      background-color: #1f2937;
-      color: #9ca3af;
-      font-style: italic;
-    }
-  </style>
+  <script src="{{ url_for('static', filename='js/dashboard.js') }}" defer></script>
   {% block head %}{% endblock %}
 </head>
 
-<body class="bg-gray-900 text-gray-200 min-h-screen px-4 py-8 font-sans">
+<body class="bg-gray-900 text-gray-200 min-h-screen px-4 py-8 font-sans"
+      data-view="{% block body_data_view %}{% endblock %}">
   <div class="max-w-screen-2xl mx-auto">
   <!-- Header -->
     <div class="text-xl font-semibold text-white mb-4">Service Tracker Dashboard</div>
@@ -106,9 +40,7 @@
     </div>
 
     <!-- Filter Bar -->
-    {% block filter_bar %}
-    <!-- Optional: Let individual pages override this -->
-    {% endblock %}
+    {% block filter_bar %}{% endblock %}
 
     <!-- Main Content -->
     <main>

--- a/templates/compact_dash.html
+++ b/templates/compact_dash.html
@@ -1,75 +1,7 @@
 {% extends "base.html" %}
+{% set active_tab = 'compact' %}
 
-{% block head %}
-<style>
-  .tile {
-    background-color: #1f2937; /* Tailwind's bg-gray-800 */
-    border: 1px solid #374151; /* Tailwind's border-gray-700 */
-    border-radius: 0.5rem;      /* Tailwind's rounded-lg */
-    padding: 0.5rem 0.75rem;    /* Tailwind's px-3 py-2 */
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    transition: background-color 0.2s ease-in-out;
-    cursor: pointer;
-    box-shadow: 0 1px 2px rgba(0,0,0,0.4); /* subtle inner shadow */
-  }
-  .tile.group-header {
-    background-color: #111827; /* Darker than regular tile (Tailwind's gray-900) */
-    border: 1px solid #4b5563; /* Tailwind's gray-600 */
-    border-left: 4px solid #3b82f6; /* Accent bar (blue-500) */
-    border-radius: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    font-weight: 700;
-    font-size: 1rem;
-    color: #ffffff;
-    text-align: center;
-    justify-content: center;
-    grid-column: span 1 / span 1;
-  }
-  .tile:hover {
-    background-color: #374151; /* Tailwind's bg-gray-700 */
-  }
-  .tile img {
-    width: 28px;
-    height: 28px;
-    border-radius: 4px;
-  }
-  .container-name {
-    font-weight: 600;
-    color: #ffffff;
-    font-size: 0.85rem;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .host-name {
-    font-size: 0.7rem;
-    color: #aaaaaa;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .tile-content {
-    overflow: hidden;
-  }
-  input[type="text"],
-  input[type="url"],
-  input[type="number"] {
-    background-color: #2d2d2d; /* Slight soft gray */
-    color: #e2e8f0;
-    border: 1px solid #4a5568;
-  }
-
-  input[type="text"]:focus,
-  input[type="url"]:focus,
-  input[type="number"]:focus {
-    border-color: #4299e1;
-    outline: none;
-    box-shadow: 0 0 0 2px rgba(66, 153, 225, 0.5);
-  }
-</style>
-{% endblock %}
+{% block body_data_view %}compact{% endblock %}
 
 {% block filter_bar %}
   {% include "partials/filter_bar.html" %}
@@ -80,12 +12,12 @@
 <div class="grid auto-cols-max grid-flow-col gap-x-6" style="grid-template-rows: repeat(10, auto);">
   {% for item in flattened_entries %}
     {% if item.is_group_header %}
-      <div class="tile group-header">
+      <div class="compact-tile group-header">
         {{ item.group }}
       </div>
     {% else %}
       {% set _target_url = item.entry.internalurl or item.entry.externalurl %}
-      <div class="tile{% if not _target_url %} cursor-default hover:bg-gray-800{% endif %}"
+      <div class="compact-tile{% if not _target_url %} cursor-default{% endif %}"
            {% if _target_url %}onclick="window.open('{{ _target_url }}', '_blank')"{% endif %}>
         <div>
           {% if item.entry.image_icon %}
@@ -96,7 +28,7 @@
             <span class="text-gray-500 text-xl">📦</span>
           {% endif %}
         </div>
-        <div class="tile-content">
+        <div style="overflow:hidden;">
           <div class="container-name" title="{{ item.entry.container_name }}">{{ item.entry.container_name }}</div>
           {% if show_host %}
           <div class="host-name" title="{{ item.entry.host }}">{{ item.entry.host }}</div>
@@ -110,34 +42,3 @@
   <p class="text-center mt-6 text-gray-400">No entries found for this view.</p>
 {% endif %}
 {% endblock %}
-
-
-{% block extra_scripts %}
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    // Filter tiles by input text
-    const filterInput = document.getElementById('filterInput');
-    if (filterInput) {
-      filterInput.addEventListener('input', function () {
-        const filter = this.value.toLowerCase();
-        const tiles = document.querySelectorAll('.tile:not(.group-header)');
-
-        tiles.forEach(tile => {
-          const containerName = tile.querySelector('.container-name')?.textContent?.toLowerCase() || '';
-          const hostName = tile.querySelector('.host-name')?.textContent?.toLowerCase() || '';
-          const groupHeader = tile.previousElementSibling?.classList.contains('group-header')
-            ? tile.previousElementSibling.textContent.toLowerCase()
-            : '';
-
-          const matches = containerName.includes(filter) ||
-                          hostName.includes(filter) ||
-                          groupHeader.includes(filter);
-
-          tile.style.display = matches ? '' : 'none';
-        });
-      });
-    }
-  });
-</script>
-{% endblock %}
-

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,30 +1,7 @@
 {% extends "base.html" %}
 {% set active_tab = 'dashboard' %}
 
-{% block head %}
-<style>
-  .logo-icon {
-    height: 40px;
-    max-width: 40px;
-    filter: drop-shadow(1px 1px 2px rgba(0, 0, 0, 0.5));
-    transition: transform 0.2s ease-in-out;
-  }
-  .logo-icon:hover {
-    transform: scale(1.1);
-  }
-  .icon-placeholder {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 40px;
-    height: 40px;
-    background-color: #3d3d3d;
-    border-radius: 4px;
-    font-size: 20px;
-    color: #9e9e9e;
-  }
-</style>
-{% endblock %}
+{% block body_data_view %}dashboard{% endblock %}
 
 {% block filter_bar %}
   {% include "partials/filter_bar.html" %}
@@ -64,7 +41,6 @@
                 <span id="toggle-icon-{{ group_index }}">▼</span>
                   {{ group }}
                   <span class="text-sm text-gray-400 ml-2">({{ group_entries|length }})</span>
-
               </td>
             </tr>
           </tbody>
@@ -76,9 +52,8 @@
                 data-container="{{ entry.container_name }}"
                 data-stack="{{ entry.stack_name }}">
 
-
             <td class="px-3 py-2">
-              <div class="logo-icon">
+              <div style="height:40px;max-width:40px;">
                 {% if entry.image_icon %}
                   {% set target_url = entry.internalurl or entry.externalurl %}
                   {% if target_url %}
@@ -86,22 +61,22 @@
                       <img src="{{ url_for('dashboard.serve_image', filename=entry.image_icon) }}"
                           class="logo-icon"
                           alt="Logo"
-                          onerror="this.style.display='none'; this.parentElement.innerHTML = '<span class=\'icon-placeholder\'>🚫</span>';">
+                          onerror="this.style.display='none'; this.parentElement.innerHTML = '<span class=\'icon-placeholder-lg\'>🚫</span>';">
                     </a>
                   {% else %}
                     <img src="{{ url_for('dashboard.serve_image', filename=entry.image_icon) }}"
                         class="logo-icon"
                         alt="Logo"
-                        onerror="this.style.display='none'; this.parentElement.innerHTML = '<span class=\'icon-placeholder\'>🚫</span>';">
+                        onerror="this.style.display='none'; this.parentElement.innerHTML = '<span class=\'icon-placeholder-lg\'>🚫</span>';">
                   {% endif %}
                 {% else %}
-                  <span class="icon-placeholder">📦</span>
+                  <span class="icon-placeholder-lg">📦</span>
                 {% endif %}
               </div>
             </td>
 
             <td class="px-3 py-2">{{ entry.group.group_name if entry.group else 'Ungrouped' }}</td>
-            
+
             <td class="px-3 py-2">
               {% set target_url = entry.internalurl or entry.externalurl %}
               {% if target_url %}
@@ -130,7 +105,6 @@
                   <div class="flex flex-wrap gap-1">
                     {% set allowed_fields = widget_fields.get(entry.widget_id, []) %}
                     {% for field, value in widget_data.items() if field in allowed_fields %}
-
                       <div class="bg-gray-800 border border-gray-700 rounded px-2 py-1 text-center min-w-[72px]">
                         <div class="text-[0.6rem] text-gray-400 uppercase tracking-wide leading-tight whitespace-nowrap">
                           {{ field.replace('_', ' ') | title }}
@@ -153,83 +127,85 @@
               {% endif %}
             </td>
 
+            {# URLs column — INT/EXT status pills with icon + label #}
             <td class="px-3 py-2 space-y-0.5">
               {% if entry.internalurl %}
-                {% set status_class = 'bg-gray-600' %}
-                {% set tooltip = entry.internalurl ~ ' — Not Monitored' %}
-                {% set display = 'NA' %}
-                {% if entry.internal_health_check_enabled %}
-                  {% if entry.internal_health_check_status == 'Error: SSLError' %}
-                    {% set status_class = 'bg-yellow-300 text-black' %}
-                    {% set tooltip = entry.internalurl ~ ' — SSL Error — updated ' ~ (entry.internal_health_check_update|time_since) %}
-                    {% set display = 'SSL' %}
-                  {% elif entry.internal_health_check_status and entry.internal_health_check_status.isdigit() and entry.internal_health_check_status|int < 400 %}
-                    {% set status_class = 'bg-green-600' %}
-                    {% set tooltip = entry.internalurl ~ ' — ' ~ entry.internal_health_check_status ~ ' — updated ' ~ (entry.internal_health_check_update|time_since) %}
-                    {% set display = entry.internal_health_check_status %}
-                  {% else %}
-                    {% set status_class = 'bg-red-600' %}
-                    {% set tooltip = entry.internalurl ~ ' — ' ~ (entry.internal_health_check_status or '?') ~ ' — updated ' ~ (entry.internal_health_check_update|time_since) %}
-                    {% set display = entry.internal_health_check_status or '?' %}
-                  {% endif %}
+                {% if not entry.internal_health_check_enabled %}
+                  {% set _i_pill  = 'status-pill-gray' %}
+                  {% set _i_label = 'NA' %}
+                  {% set _i_tip   = entry.internalurl ~ ' — Not Monitored' %}
+                {% elif entry.internal_health_check_status == 'Error: SSLError' %}
+                  {% set _i_pill  = 'status-pill-yellow' %}
+                  {% set _i_label = 'SSL' %}
+                  {% set _i_tip   = entry.internalurl ~ ' — SSL Error — updated ' ~ (entry.internal_health_check_update | time_since) %}
+                {% elif entry.internal_health_check_status and entry.internal_health_check_status.isdigit() and entry.internal_health_check_status|int < 400 %}
+                  {% set _i_pill  = 'status-pill-green' %}
+                  {% set _i_label = entry.internal_health_check_status %}
+                  {% set _i_tip   = entry.internalurl ~ ' — ' ~ entry.internal_health_check_status ~ ' — updated ' ~ (entry.internal_health_check_update | time_since) %}
+                {% else %}
+                  {% set _i_pill  = 'status-pill-red' %}
+                  {% set _i_label = entry.internal_health_check_status or '?' %}
+                  {% set _i_tip   = entry.internalurl ~ ' — ' ~ (entry.internal_health_check_status or '?') ~ ' — updated ' ~ (entry.internal_health_check_update | time_since) %}
                 {% endif %}
                 <div>
                   <span class="text-xs text-gray-400">INT:</span>
-                  <a href="{{ entry.internalurl }}" target="_blank" title="{{ tooltip }}">
-                    <span class="px-2 py-0.5 rounded text-xs font-medium {{ status_class }}">{{ display }}</span>
+                  <a href="{{ entry.internalurl }}" target="_blank" title="{{ _i_tip }}">
+                    <span class="status-pill {{ _i_pill }}">
+                      <i class="ti ti-home" aria-hidden="true"></i>{{ _i_label }}
+                    </span>
                   </a>
                 </div>
               {% endif %}
 
               {% if entry.externalurl %}
-                {% set status_class = 'bg-gray-600' %}
-                {% set tooltip = entry.externalurl ~ ' — Not Monitored' %}
-                {% set display = 'NA' %}
-                {% if entry.external_health_check_enabled %}
-                  {% if entry.external_health_check_status == 'Error: SSLError' %}
-                    {% set status_class = 'bg-yellow-300 text-black' %}
-                    {% set tooltip = entry.externalurl ~ ' — SSL Error — updated ' ~ (entry.external_health_check_update|time_since) %}
-                    {% set display = 'SSL' %}
-                  {% elif entry.external_health_check_status and entry.external_health_check_status.isdigit() and entry.external_health_check_status|int < 400 %}
-                    {% set status_class = 'bg-green-600' %}
-                    {% set tooltip = entry.externalurl ~ ' — ' ~ entry.external_health_check_status ~ ' — updated ' ~ (entry.external_health_check_update|time_since) %}
-                    {% set display = entry.external_health_check_status %}
-                  {% else %}
-                    {% set status_class = 'bg-red-600' %}
-                    {% set tooltip = entry.externalurl ~ ' — ' ~ (entry.external_health_check_status or '?') ~ ' — updated ' ~ (entry.external_health_check_update|time_since) %}
-                    {% set display = entry.external_health_check_status or '?' %}
-                  {% endif %}
+                {% if not entry.external_health_check_enabled %}
+                  {% set _e_pill  = 'status-pill-gray' %}
+                  {% set _e_label = 'NA' %}
+                  {% set _e_tip   = entry.externalurl ~ ' — Not Monitored' %}
+                {% elif entry.external_health_check_status == 'Error: SSLError' %}
+                  {% set _e_pill  = 'status-pill-yellow' %}
+                  {% set _e_label = 'SSL' %}
+                  {% set _e_tip   = entry.externalurl ~ ' — SSL Error — updated ' ~ (entry.external_health_check_update | time_since) %}
+                {% elif entry.external_health_check_status and entry.external_health_check_status.isdigit() and entry.external_health_check_status|int < 400 %}
+                  {% set _e_pill  = 'status-pill-green' %}
+                  {% set _e_label = entry.external_health_check_status %}
+                  {% set _e_tip   = entry.externalurl ~ ' — ' ~ entry.external_health_check_status ~ ' — updated ' ~ (entry.external_health_check_update | time_since) %}
+                {% else %}
+                  {% set _e_pill  = 'status-pill-red' %}
+                  {% set _e_label = entry.external_health_check_status or '?' %}
+                  {% set _e_tip   = entry.externalurl ~ ' — ' ~ (entry.external_health_check_status or '?') ~ ' — updated ' ~ (entry.external_health_check_update | time_since) %}
                 {% endif %}
                 <div>
                   <span class="text-xs text-gray-400">EXT:</span>
-                  <a href="{{ entry.externalurl }}" target="_blank" title="{{ tooltip }}">
-                    <span class="px-2 py-0.5 rounded text-xs font-medium {{ status_class }}">{{ display }}</span>
+                  <a href="{{ entry.externalurl }}" target="_blank" title="{{ _e_tip }}">
+                    <span class="status-pill {{ _e_pill }}">
+                      <i class="ti ti-world" aria-hidden="true"></i>{{ _e_label }}
+                    </span>
                   </a>
                 </div>
               {% endif %}
             </td>
 
-            
-
+            {# Status column — Docker pill with icon + label #}
             <td class="px-3 py-2">
               {% if not entry.is_static %}
-                {% set tooltip = entry.last_api_update | time_since if entry.last_api_update else 'No update timestamp' %}
-                {% set timestamp = entry.last_api_update if entry.last_api_update else '' %}
-                
+                {% set _d_tooltip = (entry.last_api_update | time_since) if entry.last_api_update else 'No update timestamp' %}
+
                 {% if not entry.last_api_update %}
-                  {% set status_class = 'bg-red-600' %}
+                  {% set _d_pill = 'status-pill-red' %}
                 {% elif entry.docker_status in ['start', 'running'] %}
-                  {% set status_class = 'bg-green-600' %}
+                  {% set _d_pill = 'status-pill-green' %}
                 {% elif entry.docker_status in ['die', 'exited'] %}
-                  {% set status_class = 'bg-red-600' %}
+                  {% set _d_pill = 'status-pill-red' %}
                 {% elif entry.docker_status %}
-                  {% set status_class = 'bg-yellow-400 text-black' %}
+                  {% set _d_pill = 'status-pill-yellow' %}
                 {% else %}
-                  {% set status_class = 'bg-gray-600' %}
+                  {% set _d_pill = 'status-pill-gray' %}
                 {% endif %}
 
-                <span class="px-2 py-0.5 rounded text-xs font-medium {{ status_class }}" title="Updated {{ tooltip }} — {{ timestamp }}">
-                  {{ entry.docker_status or 'Unknown' }}
+                <span class="status-pill {{ _d_pill }}"
+                      title="Updated {{ _d_tooltip }}{% if entry.last_api_update %} — {{ entry.last_api_update }}{% endif %}">
+                  <i class="ti ti-brand-docker" aria-hidden="true"></i>{{ entry.docker_status or 'Unknown' }}
                 </span>
 
                 {% if entry.image_tag %}
@@ -240,20 +216,25 @@
               {% endif %}
             </td>
 
+            {# Tools column — Dozzle link via Tabler icon #}
             {% if display_tools %}
               <td class="px-3 py-2">
                 {% if STD_DOZZLE_URL and entry.container_id %}
-                  <a href="{{ STD_DOZZLE_URL }}/container/{{ entry.container_id[:12] }}" target="_blank">
-                    <img src="{{ url_for('static', filename='dozzle.svg') }}" alt="Dozzle" class="h-5" />
+                  <a href="{{ STD_DOZZLE_URL }}/container/{{ entry.container_id[:12] }}" target="_blank"
+                     title="Open logs in Dozzle">
+                    <i class="ti ti-terminal-2 text-gray-400 hover:text-gray-200" style="font-size:20px;"></i>
                   </a>
                 {% endif %}
               </td>
             {% endif %}
 
-
-
+            {# Actions column — pencil icon edit + static lock indicator #}
             <td class="px-3 py-2">
-              <a href="{{ url_for('dashboard.edit_entry', id=entry.id, ref=request.full_path) }}" class="border border-yellow-400 text-yellow-300 text-xs px-2 py-0.5 rounded hover:bg-yellow-400 hover:text-black transition">Edit</a>
+              <a href="{{ url_for('dashboard.edit_entry', id=entry.id, ref=request.full_path) }}"
+                 class="inline-flex items-center justify-center border border-yellow-400 text-yellow-300 rounded p-1 hover:bg-yellow-400 hover:text-black transition"
+                 title="Edit">
+                <i class="ti ti-edit" aria-hidden="true" style="font-size:14px;"></i>
+              </a>
               {% if entry.is_static %}
                 <span title="Static entry — API updates blocked" class="ml-2">🔒</span>
               {% endif %}
@@ -263,86 +244,6 @@
         </tbody>
         {% endfor %}
       </table>
-      
+
 </div>
-{% endblock %}
-
-{% block extra_scripts %}
-<script>
-  let secondsSinceRefresh = 0;
-  let refreshInterval = 60;
-
-  document.addEventListener('DOMContentLoaded', function () {
-    const filterInput = document.getElementById('filterInput');
-    const refreshLabel = document.getElementById('refreshTimer');
-    const refreshDropdown = document.getElementById('refreshInterval');
-
-    const rows = document.querySelectorAll('table tbody tr[data-entry]');
-    if (filterInput) {
-      filterInput.addEventListener('input', function () {
-        const filter = this.value.toLowerCase();
-        rows.forEach(row => {
-          const group = row.dataset.group.toLowerCase();
-          const name = row.dataset.container.toLowerCase();
-          const stack = row.dataset.stack.toLowerCase();
-          row.style.display = (group.includes(filter) || name.includes(filter) || stack.includes(filter)) ? '' : 'none';
-        });
-      });
-    }
-
-    const savedInterval = localStorage.getItem('refreshInterval');
-    if (savedInterval !== null) {
-      refreshInterval = parseInt(savedInterval);
-      if (refreshDropdown) refreshDropdown.value = savedInterval;
-    }
-
-    if (refreshDropdown) {
-      refreshDropdown.addEventListener('change', function () {
-        refreshInterval = parseInt(this.value);
-        localStorage.setItem('refreshInterval', this.value);
-      });
-    }
-
-    setInterval(() => {
-      secondsSinceRefresh++;
-      if (refreshLabel) {
-        const m = Math.floor(secondsSinceRefresh / 60);
-        const s = secondsSinceRefresh % 60;
-        refreshLabel.textContent = `Refreshed ${m > 0 ? m + 'm ' : ''}${s}s ago`;
-      }
-      if (refreshInterval > 0 && secondsSinceRefresh >= refreshInterval) {
-        window.location.reload();
-      }
-    }, 1000);
-
-    // Restore group collapse
-    const allGroups = document.querySelectorAll('[id^="toggle-icon-"]');
-    allGroups.forEach(iconEl => {
-      const groupId = iconEl.id.replace('toggle-icon-', '');
-      const isCollapsed = localStorage.getItem(`group-collapsed-${groupId}`) === 'true';
-      const entries = document.querySelectorAll(`tr.group-entry[data-group-id='${groupId}']`);
-      entries.forEach(row => row.style.display = isCollapsed ? 'none' : '');
-      iconEl.textContent = isCollapsed ? '▶' : '▼';
-    });
-
-  });
-
-  function toggleGroup(groupId) {
-    const entries = document.querySelectorAll(`tr.group-entry[data-group-id='${groupId}']`);
-    const icon = document.getElementById(`toggle-icon-${groupId}`);
-    let isCollapsed = localStorage.getItem(`group-collapsed-${groupId}`) === 'true';
-    const newState = !isCollapsed;
-    entries.forEach(row => row.style.display = newState ? 'none' : '');
-    if (icon) icon.textContent = newState ? '▶' : '▼';
-    localStorage.setItem(`group-collapsed-${groupId}`, newState);
-  }
-
-  function copyToClipboard(text, el) {
-    navigator.clipboard.writeText(text).then(() => {
-      const original = el.innerHTML;
-      el.innerHTML = "<em>Copied!</em>";
-      setTimeout(() => el.innerHTML = original, 1000);
-    });
-  }
-</script>
 {% endblock %}

--- a/templates/partials/exposure_badges.html
+++ b/templates/partials/exposure_badges.html
@@ -6,8 +6,8 @@
 
    Visual conventions:
    - badge text: the layer name (truncated to 8 chars).
-   - TLS-terminated: 🔒 prefix.
-   - auth required (auth not in {null, "none", ""}): 🔑 suffix.
+   - TLS-terminated: ti-lock icon prefix.
+   - auth required (auth not in {null, "none", ""}): ti-key suffix.
 #}
 {% if exposures %}
   {% set _shown = exposures[:3] %}
@@ -18,9 +18,9 @@
       {% set _auth_required = ex.auth and ex.auth not in ['none', ''] %}
       <span class="exposure-badge"
             title="{{ ex.layer }}{% if ex.hostname %} — {{ ex.hostname }}{% endif %}{% if ex.tls %} (TLS){% endif %}{% if _auth_required %} (auth: {{ ex.auth }}){% endif %}">
-        {% if ex.tls %}<span class="exposure-badge-icon">🔒</span>{% endif %}
+        {% if ex.tls %}<i class="ti ti-lock exposure-badge-icon" aria-hidden="true"></i>{% endif %}
         <span class="exposure-badge-label">{{ _label }}</span>
-        {% if _auth_required %}<span class="exposure-badge-icon">🔑</span>{% endif %}
+        {% if _auth_required %}<i class="ti ti-key exposure-badge-icon" aria-hidden="true"></i>{% endif %}
       </span>
     {% endfor %}
     {% if _overflow > 0 %}

--- a/templates/partials/filter_bar.html
+++ b/templates/partials/filter_bar.html
@@ -29,17 +29,6 @@
   </div>
 
   <div class="flex gap-2 items-center mt-2 sm:mt-0">
-    {% if active_tab == 'tiled' %}
-    <div class="flex items-center gap-3">
-      <label for="toggleWidgets" class="text-sm text-gray-300">Show Widgets:</label>
-      <label class="relative inline-flex items-center cursor-pointer">
-        <input type="checkbox" id="toggleWidgets" class="sr-only peer">
-        <div class="w-11 h-6 bg-gray-600 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-500 rounded-full peer-checked:bg-blue-600 transition-all"></div>
-        <div class="absolute left-0.5 top-0.5 w-5 h-5 bg-white rounded-full transition-transform transform peer-checked:translate-x-full"></div>
-      </label>
-    </div>
-    {% endif %}
-
     <label for="refreshInterval" class="text-sm text-gray-400">Auto Refresh:</label>
     <select id="refreshInterval" class="bg-gray-800 border border-gray-600 px-2 py-1 rounded text-sm text-white">
       <option value="30">30s</option>
@@ -52,26 +41,3 @@
     <div id="refreshTimer" class="text-sm text-gray-400 cursor-pointer" onclick="window.location.reload()">Refreshed just now</div>
   </div>
 </div>
-
-<script>
-  // Shared submit-on-change handler for all view controls. Each control
-  // has data-param=<query-key>; checkboxes write 'true'/'false', selects
-  // write their value. URL state is the single source of truth so the
-  // dashboard is bookmarkable and shareable.
-  document.addEventListener('DOMContentLoaded', function () {
-    document.querySelectorAll('.view-control').forEach(function (el) {
-      el.addEventListener('change', function () {
-        var params = new URLSearchParams(window.location.search);
-        var key = this.dataset.param;
-        var value;
-        if (this.type === 'checkbox') {
-          value = this.checked ? 'true' : 'false';
-        } else {
-          value = this.value;
-        }
-        params.set(key, value);
-        window.location.search = params.toString();
-      });
-    });
-  });
-</script>

--- a/templates/tiled_dash.html
+++ b/templates/tiled_dash.html
@@ -1,179 +1,11 @@
 {% extends "base.html" %}
 {% set active_tab = 'tiled' %}
 
-{% block head %}
-<style>
-  body {
-    background-color: #111827;
-    color: #e5e7eb;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    margin: 0;
-    padding: 15px;
-  }
-  .page-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 20px;
-    padding-bottom: 10px;
-    border-bottom: 1px solid #374151;
-  }
-  .page-header h1 {
-    font-size: 1.8em;
-    color: #ffffff;
-    margin: 0;
-  }
-  .group-title {
-    font-size: 1.4em;
-    color: #e5e7eb;
-    margin-top: 25px;
-    margin-bottom: 12px;
-    padding-bottom: 5px;
-    border-bottom: 2px solid #374151;
-  }
-  .tile-container {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
-    gap: 10px;
-  }
-  .tile {
-    display: flex;
-    align-items: center;
-    background-color: #1f2937;
-    border: 1px solid #374151;
-    border-radius: 6px;
-    padding: 10px;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.4);
-    transition: box-shadow 0.2s ease-in-out, border-color 0.2s ease-in-out;
-  }
-  .tile:hover {
-    box-shadow: 0 2px 8px rgba(0,0,0,0.6);
-    border-color: #3b82f6;
-  }
-  .tile-icon {
-    flex-shrink: 0;
-    margin-right: 10px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-  }
-  .tile-icon img {
-    max-width: 100%;
-    max-height: 100%;
-    border-radius: 4px;
-  }
-  .icon-placeholder {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-    background-color: #374151;
-    border-radius: 4px;
-    font-size: 18px;
-    color: #9ca3af;
-  }
-  .tile-details {
-    flex-grow: 1;
-    margin-right: 8px;
-    overflow: hidden;
-  }
-  .container-name {
-    font-weight: 600;
-    color: #f9fafb;
-    display: block;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    font-size: 0.95em;
-  }
-  .host-name {
-    font-size: 0.75em;
-    color: #9ca3af;
-    display: block;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .tile-statuses {
-    display: flex;
-    align-items: center;
-  }
-  .tile-web-statuses {
-    margin-right: 6px;
-    width: 36px;
-  }
-  .status-button {
-    display: inline-block;
-    vertical-align: middle;
-    border: none;
-    border-radius: 4px;
-    color: white;
-    text-decoration: none;
-    text-align: center;
-    transition: opacity 0.2s;
-    font-weight: 500;
-    box-sizing: border-box;
-  }
-  .status-button:hover {
-    opacity: 0.85;
-  }
-  .tile-web-statuses .status-button {
-    display: block;
-    width: 100%;
-    padding: 3px 0;
-    font-size: 9px;
-    line-height: 1.2;
-    margin-bottom: 2px;
-  }
-  .tile-web-statuses .status-button:last-child {
-    margin-bottom: 0;
-  }
-  .docker-status-button {
-    padding: 3px 7px;
-    font-size: 0.7em;
-    min-width: 55px;
-  }
-  .dozzle-direct-link {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    margin-left: 8px;
-    line-height: 0;
-  }
-  .dozzle-icon-img {
-    width: 18px;
-    height: 18px;
-    opacity: 0.65;
-    transition: opacity 0.2s ease-in-out;
-  }
-  .dozzle-direct-link:hover .dozzle-icon-img {
-    opacity: 1;
-  }
-  .status-button-good { background-color: #16a34a; }
-  .status-button-bad { background-color: #dc2626; }
-  .status-button-unknown { background-color: #6b7280; }
-  .status-button-stale { background-color: #f59e0b; color: #fff; }
-  .widget-box {
-    transition: all 0.3s ease-in-out;
-    background-color: #1f2937;
-    border: 1px solid #374151;
-  }
-  /* Headless tile — no exposure rows and no URLs. Removes hover
-     border highlight + cursor cue since there's nothing to click.
-     Exposure badge styles live in base.html so they're available on
-     every dashboard view. */
-  .tile.tile-headless { cursor: default; }
-  .tile.tile-headless:hover { border-color: #374151; box-shadow: 0 1px 3px rgba(0,0,0,0.4); }
-</style>
-{% endblock %}
+{% block body_data_view %}tiled{% endblock %}
 
 {% block filter_bar %}
   {% include "partials/filter_bar.html" %}
 {% endblock %}
-
 
 {% block content %}
     {% if grouped_entries %}
@@ -186,275 +18,399 @@
 
             <div class="tile-container" data-group-container="{{ group_name }}">
                 {% for entry in entries_in_group %}
-                    {% set _is_headless = (not entry.internalurl) and (not entry.externalurl) and (not entry.exposures) %}
+                    {# ── Pre-compute status classes and tooltips ────────── #}
+                    {% set _is_headless = (not entry.internalurl) and (not entry.externalurl) and (not entry.exposures) and (not entry.widget_id) %}
+
+                    {# Internal URL status #}
+                    {% if not entry.internalurl %}
+                      {% set _int_class   = 'status-icon-muted' %}
+                      {% set _int_tooltip = 'Internal URL not configured' %}
+                      {% set _int_href    = '' %}
+                    {% elif not entry.internal_health_check_enabled %}
+                      {% set _int_class   = 'status-icon-muted' %}
+                      {% set _int_tooltip = 'Internal: monitoring disabled' %}
+                      {% set _int_href    = entry.internalurl %}
+                    {% elif entry.internal_health_check_status == 'Error: SSLError' %}
+                      {% set _int_class   = 'status-icon-warn' %}
+                      {% set _int_tooltip = 'Internal: SSL error (' ~ (entry.internal_health_check_update | time_since) ~ ')' %}
+                      {% set _int_href    = entry.internalurl %}
+                    {% elif entry.internal_health_check_status and entry.internal_health_check_status.isdigit() and entry.internal_health_check_status|int < 400 %}
+                      {% set _int_class   = 'status-icon-ok' %}
+                      {% set _int_tooltip = 'Internal: ' ~ entry.internal_health_check_status ~ ' (' ~ (entry.internal_health_check_update | time_since) ~ ')' %}
+                      {% set _int_href    = entry.internalurl %}
+                    {% elif entry.internal_health_check_status %}
+                      {% set _int_class   = 'status-icon-bad' %}
+                      {% set _int_tooltip = 'Internal: ' ~ entry.internal_health_check_status ~ ' (' ~ (entry.internal_health_check_update | time_since) ~ ')' %}
+                      {% set _int_href    = entry.internalurl %}
+                    {% else %}
+                      {% set _int_class   = 'status-icon-muted' %}
+                      {% set _int_tooltip = 'Internal: no data yet' %}
+                      {% set _int_href    = entry.internalurl %}
+                    {% endif %}
+
+                    {# External URL status #}
+                    {% if not entry.externalurl %}
+                      {% set _ext_class   = 'status-icon-muted' %}
+                      {% set _ext_tooltip = 'External URL not configured' %}
+                      {% set _ext_href    = '' %}
+                    {% elif not entry.external_health_check_enabled %}
+                      {% set _ext_class   = 'status-icon-muted' %}
+                      {% set _ext_tooltip = 'External: monitoring disabled' %}
+                      {% set _ext_href    = entry.externalurl %}
+                    {% elif entry.external_health_check_status == 'Error: SSLError' %}
+                      {% set _ext_class   = 'status-icon-warn' %}
+                      {% set _ext_tooltip = 'External: SSL error (' ~ (entry.external_health_check_update | time_since) ~ ')' %}
+                      {% set _ext_href    = entry.externalurl %}
+                    {% elif entry.external_health_check_status and entry.external_health_check_status.isdigit() and entry.external_health_check_status|int < 400 %}
+                      {% set _ext_class   = 'status-icon-ok' %}
+                      {% set _ext_tooltip = 'External: ' ~ entry.external_health_check_status ~ ' (' ~ (entry.external_health_check_update | time_since) ~ ')' %}
+                      {% set _ext_href    = entry.externalurl %}
+                    {% elif entry.external_health_check_status %}
+                      {% set _ext_class   = 'status-icon-bad' %}
+                      {% set _ext_tooltip = 'External: ' ~ entry.external_health_check_status ~ ' (' ~ (entry.external_health_check_update | time_since) ~ ')' %}
+                      {% set _ext_href    = entry.externalurl %}
+                    {% else %}
+                      {% set _ext_class   = 'status-icon-muted' %}
+                      {% set _ext_tooltip = 'External: no data yet' %}
+                      {% set _ext_href    = entry.externalurl %}
+                    {% endif %}
+
+                    {# Docker status #}
+                    {% set _docker_status_lower = entry.docker_status.lower() if entry.docker_status else 'unknown' %}
+                    {% set _is_good_docker = ('running' in _docker_status_lower and 'unhealthy' not in _docker_status_lower) or 'healthy' in _docker_status_lower %}
+                    {% set _is_bad_docker  = 'exited' in _docker_status_lower or 'dead' in _docker_status_lower or 'unhealthy' in _docker_status_lower or 'restarting' in _docker_status_lower or 'removing' in _docker_status_lower or 'paused' in _docker_status_lower %}
+                    {% set _docker_age_min = ((now() - entry.last_api_update).total_seconds() / 60) if entry.last_api_update else None %}
+
+                    {% if entry.is_static %}
+                      {% set _docker_class   = 'status-icon-muted' %}
+                      {% set _docker_tooltip = 'Static entry' %}
+                    {% elif not entry.last_api_update %}
+                      {% set _docker_class   = 'status-icon-bad' %}
+                      {% set _docker_tooltip = 'Docker: no update received' %}
+                    {% elif entry.is_docker_status_stale or (_is_good_docker and _docker_age_min and _docker_age_min > 120) %}
+                      {% set _docker_class   = 'status-icon-warn' %}
+                      {% set _docker_tooltip = 'Docker: ' ~ (entry.docker_status or 'unknown') ~ ' — stale (' ~ (entry.last_api_update | time_since) ~ ')' %}
+                    {% elif _is_good_docker %}
+                      {% set _docker_class   = 'status-icon-ok' %}
+                      {% set _docker_tooltip = 'Docker: ' ~ (entry.docker_status or 'unknown') ~ ' — updated ' ~ (entry.last_api_update | time_since) %}
+                    {% elif _is_bad_docker %}
+                      {% set _docker_class   = 'status-icon-bad' %}
+                      {% set _docker_tooltip = 'Docker: ' ~ (entry.docker_status or 'unknown') ~ ' — updated ' ~ (entry.last_api_update | time_since) %}
+                    {% else %}
+                      {% set _docker_class   = 'status-icon-muted' %}
+                      {% set _docker_tooltip = 'Docker: ' ~ (entry.docker_status or 'unknown') %}
+                    {% endif %}
+
+                    {# Dozzle link #}
+                    {% set _dozzle_base = STD_DOZZLE_URL %}
+                    {% set _dozzle_id   = entry.container_id %}
+                    {% set _has_dozzle  = _dozzle_base and _dozzle_id %}
+
+                    {# ── Tile wrapper ──────────────────────────────────── #}
                     <div class="tile-wrapper">
                         <div class="tile{% if _is_headless %} tile-headless{% endif %}"
-                        data-internalurl="{{ entry.internalurl if entry.internalurl else '' }}"
-                        data-externalurl="{{ entry.externalurl if entry.externalurl else '' }}">
-                        <div class="tile-icon">
-                            {% if entry.image_icon %}
-                                <img src="{{ url_for('dashboard.serve_image', filename=entry.image_icon) }}"
-                                     alt="{{ entry.container_name }} icon"
-                                     onerror="this.style.display='none'; this.parentElement.innerHTML = '<span class=\'icon-placeholder\'>🚫</span>';">
-                            {% else %}
-                                <span class="icon-placeholder">📦</span>
-                            {% endif %}
-                        </div>
-                        <div class="tile-details">
-                            <strong class="container-name" title="{{ entry.container_name }}">{{ entry.container_name }}</strong>
-                            <small class="host-name" title="{{ entry.host }}">{{ entry.host }}</small>
-                            {% with exposures = entry.exposures %}
-                              {% include "partials/exposure_badges.html" %}
-                            {% endwith %}
-                        </div>
+                             data-internalurl="{{ entry.internalurl if entry.internalurl else '' }}"
+                             data-externalurl="{{ entry.externalurl if entry.externalurl else '' }}">
 
-                        <div class="tile-statuses">
-                            <div class="tile-web-statuses">
-                                {% set internal_status_class =
-                                    'status-button-good' if entry.internal_health_check_status == '200' else
-                                    'status-button-stale' if entry.internal_health_check_status == 'Error: SSLError' else
-                                    'status-button-bad' if entry.internal_health_check_status else
-                                    'status-button-unknown' %}
-
-                                {% set external_status_class =
-                                    'status-button-good' if entry.external_health_check_status == '200' else
-                                    'status-button-stale' if entry.external_health_check_status == 'Error: SSLError' else
-                                    'status-button-bad' if entry.external_health_check_status else
-                                    'status-button-unknown' %}
-
-                                {% if entry.internalurl and entry.internal_health_check_enabled %}
-                                    <a href="{{ entry.internalurl }}" target="_blank"
-                                    class="status-button {{ internal_status_class }}"
-                                    title="Internal: {{ entry.internal_health_check_status or 'N/A' }} ({{ entry.internal_health_check_update | time_since }})">
-                                        INT
-                                    </a>
-                                {% endif %}
-                                
-                                {% if entry.externalurl and entry.external_health_check_enabled %}
-                                    <a href="{{ entry.externalurl }}" target="_blank"
-                                    class="status-button {{ external_status_class }}"
-                                    title="External: {{ entry.external_health_check_status or 'N/A' }} ({{ entry.external_health_check_update | time_since }})">
-                                        EXT
-                                    </a>
+                            {# Icon #}
+                            <div class="tile-icon">
+                                {% if entry.image_icon %}
+                                    <img src="{{ url_for('dashboard.serve_image', filename=entry.image_icon) }}"
+                                         alt="{{ entry.container_name }} icon"
+                                         onerror="this.style.display='none'; this.parentElement.innerHTML = '<span class=\'icon-placeholder\'>🚫</span>';">
+                                {% else %}
+                                    <span class="icon-placeholder">📦</span>
                                 {% endif %}
                             </div>
 
-                            {% if not entry.is_static %}
-                            <div class="tile-docker-status">
-                                
-                                {% set docker_status_lower = entry.docker_status.lower() if entry.docker_status else 'unknown' %}
-                                
-                                {% set _is_good_docker = ('running' in docker_status_lower and 'unhealthy' not in docker_status_lower) or 'healthy' in docker_status_lower %}
-                                {% set _is_bad_docker = 'exited' in docker_status_lower or 'dead' in docker_status_lower or 'unhealthy' in docker_status_lower or 'restarting' in docker_status_lower or 'removing' in docker_status_lower or 'paused' in docker_status_lower %}
-                                
-                                {% set docker_age_minutes = ((now() - entry.last_api_update).total_seconds() / 60) if entry.last_api_update else None %}
+                            {# Details column: name + exposure badges #}
+                            <div class="tile-details">
+                                <strong class="container-name" title="{{ entry.container_name }}">{{ entry.container_name }}</strong>
+                                {% with exposures = entry.exposures %}
+                                  {% include "partials/exposure_badges.html" %}
+                                {% endwith %}
+                            </div>
 
-                                {% set docker_class =
-                                    'status-button-stale' if entry.is_docker_status_stale else
-                                    'status-button-stale' if _is_good_docker and docker_age_minutes and docker_age_minutes > 120 else
-                                    'status-button-good' if _is_good_docker else
-                                    'status-button-bad' if _is_bad_docker else
-                                    'status-button-unknown' %}
+                            {# Status icon row #}
+                            <div class="tile-status-row">
 
-                                {% if not entry.last_api_update %}
-                                {% set docker_class = 'status-button-bad' %}
+                                {# Internal URL icon #}
+                                {% if _int_href %}
+                                    <a href="{{ _int_href }}" target="_blank"
+                                       class="status-icon {{ _int_class }}"
+                                       title="{{ _int_tooltip }}"
+                                       onclick="event.stopPropagation()">
+                                        <i class="ti ti-home" aria-hidden="true"></i>
+                                    </a>
                                 {% else %}
-                                {% set docker_class =
-                                    'status-button-stale' if entry.is_docker_status_stale else
-                                    'status-button-stale' if _is_good_docker and docker_age_minutes and docker_age_minutes > 120 else
-                                    'status-button-good' if _is_good_docker else
-                                    'status-button-bad' if _is_bad_docker else
-                                    'status-button-unknown' %}
+                                    <span class="status-icon {{ _int_class }}" title="{{ _int_tooltip }}">
+                                        <i class="ti ti-home" aria-hidden="true"></i>
+                                    </span>
                                 {% endif %}
 
-                                {% set display_docker_status = (entry.docker_status.split('(')[0].strip() if entry.docker_status else 'N/A') %}
-                                
-                                <span
-                                class="status-button docker-status-button {{ docker_class }}"
-                                title="Docker: {{ entry.docker_status or 'N/A' }} — {% if entry.last_api_update %}last updated {{ entry.last_api_update | time_since }}{% else %}no update timestamp{% endif %}">
-                                {{ display_docker_status[:9] }}{{ '…' if display_docker_status|length > 9 else '' }}
+                                {# External URL icon #}
+                                {% if _ext_href %}
+                                    <a href="{{ _ext_href }}" target="_blank"
+                                       class="status-icon {{ _ext_class }}"
+                                       title="{{ _ext_tooltip }}"
+                                       onclick="event.stopPropagation()">
+                                        <i class="ti ti-world" aria-hidden="true"></i>
+                                    </a>
+                                {% else %}
+                                    <span class="status-icon {{ _ext_class }}" title="{{ _ext_tooltip }}">
+                                        <i class="ti ti-world" aria-hidden="true"></i>
+                                    </span>
+                                {% endif %}
+
+                                {# Docker status icon (dynamic entries only) #}
+                                {% if not entry.is_static %}
+                                    <span class="status-icon {{ _docker_class }}" title="{{ _docker_tooltip }}">
+                                        <i class="ti ti-brand-docker" aria-hidden="true"></i>
+                                    </span>
+                                {% else %}
+                                    <span class="status-icon status-icon-muted" title="Static entry">
+                                        <i class="ti ti-brand-docker" aria-hidden="true"></i>
+                                    </span>
+                                {% endif %}
+
+                                <span class="icon-sep" aria-hidden="true"></span>
+
+                                {# Widget indicator #}
+                                {% if entry.widget_id %}
+                                    <span class="status-icon status-icon-blue" title="Widget data — click chevron to expand">
+                                        <i class="ti ti-chart-line" aria-hidden="true"></i>
+                                    </span>
+                                {% endif %}
+
+                                {# Dozzle icon #}
+                                {% if _has_dozzle %}
+                                    <a href="{{ _dozzle_base }}/container/{{ _dozzle_id[:12] }}"
+                                       target="_blank"
+                                       class="status-icon status-icon-muted"
+                                       title="Open logs in Dozzle ({{ _dozzle_id[:12] }})"
+                                       onclick="event.stopPropagation()">
+                                        <i class="ti ti-terminal-2" aria-hidden="true"></i>
+                                    </a>
+                                {% endif %}
+
+                                {# Edit icon #}
+                                <a href="{{ url_for('dashboard.edit_entry', id=entry.id, ref=request.full_path) }}"
+                                   class="status-icon status-icon-muted"
+                                   title="Edit"
+                                   onclick="event.stopPropagation()">
+                                    <i class="ti ti-edit" aria-hidden="true"></i>
+                                </a>
+
+                                {# Expand chevron #}
+                                <button class="tile-chevron"
+                                        data-drawer="drawer-{{ entry.id }}"
+                                        aria-expanded="false"
+                                        aria-label="Expand details for {{ entry.container_name }}"
+                                        title="Expand details">
+                                    <i class="ti ti-chevron-down" aria-hidden="true"></i>
+                                </button>
+                            </div>{# /tile-status-row #}
+
+                        </div>{# /tile #}
+
+                        {# ── Expand drawer ─────────────────────────────── #}
+                        <div class="tile-drawer" id="drawer-{{ entry.id }}">
+
+                            {# ── Info rows ─────────────────────────── #}
+
+                            {# Host #}
+                            <div class="drawer-row">
+                                <span class="drawer-label">Host</span>
+                                <span class="drawer-value">{{ entry.host }}</span>
+                            </div>
+
+                            {# Internal URL #}
+                            {% if entry.internalurl %}
+                            <div class="drawer-row">
+                                <span class="drawer-label">Internal</span>
+                                <span class="drawer-value">
+                                    <a href="{{ entry.internalurl }}" target="_blank"
+                                       class="text-blue-400 hover:underline break-all">{{ entry.internalurl }}</a>
+                                    {% if entry.internal_health_check_enabled and entry.internal_health_check_status %}
+                                      <span class="ml-1 text-gray-400 text-xs">
+                                        — {{ entry.internal_health_check_status }}
+                                        {% if entry.internal_health_check_update %}
+                                          ({{ entry.internal_health_check_update | time_since }})
+                                        {% endif %}
+                                      </span>
+                                    {% endif %}
+                                </span>
+                            </div>
+                            {% endif %}
+
+                            {# External URL #}
+                            {% if entry.externalurl %}
+                            <div class="drawer-row">
+                                <span class="drawer-label">External</span>
+                                <span class="drawer-value">
+                                    <a href="{{ entry.externalurl }}" target="_blank"
+                                       class="text-blue-400 hover:underline break-all">{{ entry.externalurl }}</a>
+                                    {% if entry.external_health_check_enabled and entry.external_health_check_status %}
+                                      <span class="ml-1 text-gray-400 text-xs">
+                                        — {{ entry.external_health_check_status }}
+                                        {% if entry.external_health_check_update %}
+                                          ({{ entry.external_health_check_update | time_since }})
+                                        {% endif %}
+                                      </span>
+                                    {% endif %}
+                                </span>
+                            </div>
+                            {% endif %}
+
+                            {# Docker status (dynamic entries only) #}
+                            {% if not entry.is_static %}
+                            <div class="drawer-row">
+                                <span class="drawer-label">Docker</span>
+                                <span class="drawer-value">
+                                    {{ entry.docker_status or 'Unknown' }}
+                                    {% if entry.last_api_update %}
+                                      <span class="text-gray-400 text-xs ml-1">({{ entry.last_api_update | time_since }})</span>
+                                    {% endif %}
+                                    {% if entry.image_tag %}
+                                      <span class="text-gray-400 text-xs ml-1">— <code>{{ entry.image_tag }}</code></span>
+                                    {% endif %}
+                                </span>
+                            </div>
+                            {% endif %}
+
+                            {# Networks #}
+                            <div class="drawer-row">
+                                <span class="drawer-label">Networks</span>
+                                <span class="drawer-value">
+                                    {% if entry.networks %}
+                                        {% for net in entry.networks %}
+                                            <span>{{ net.name }}{% if net.aliases %} <span class="text-gray-400">[{{ net.aliases | join(', ') }}]</span>{% endif %}</span>{% if not loop.last %}, {% endif %}
+                                        {% endfor %}
+                                    {% else %}
+                                        <em class="text-gray-500">Not reported</em>
+                                    {% endif %}
                                 </span>
                             </div>
 
-                            {% set dozzle_url = entry.dozzle_url_override if entry.dozzle_url_override else STD_DOZZLE_URL %}
-                            {% set container_id = entry.container_id_override if entry.container_id_override else entry.container_id %}
-                            {% if dozzle_url and container_id %}
-                                <a href="{{ dozzle_url }}/container/{{ container_id[:12] }}"
-                                target="_blank"
-                                class="dozzle-direct-link"
-                                title="Open Logs in Dozzle ({{ container_id[:12] }})">
-                                <img src="{{ url_for('static', filename='dozzle.svg')  }}"
-                                    alt="Dozzle Logs"
-                                    class="dozzle-icon-img">
-                                </a>
-                            {% endif %}
-                            {% endif %}
-
-
-
-                        </div>
-                    </div>
-
-                    {% if entry.widget_id %}
-                        {% set widget_data = widget_values.get(entry.widget_id) %}
-                        {% set last_updated = widget_data.get('last_updated') if widget_data else None %}
-                        <div class="widget-box mt-2 px-2 py-1 rounded-lg bg-gray-800 border border-gray-700 text-sm text-gray-100 hidden"
-                        data-widget-for="{{ entry.widget_id }}"
-                        {% if last_updated %}
-                            title="Last updated: {{ last_updated }}"
-                        {% endif %}>   
-                            {% if widget_data %}
-                                {% set allowed_fields = widget_fields.get(entry.widget_id, []) %}
-                                <div class="grid grid-cols-3 gap-2">
-                                    {% for field, value in widget_data.items() if field in allowed_fields %}
-                                        <div class="bg-gray-700 rounded-md px-2 py-1 text-center shadow-sm border border-gray-600">
-                                            <div class="text-[0.65rem] text-gray-400 uppercase tracking-wide leading-tight">
-                                                {{ field.replace('_', ' ') | title }}
-                                            </div>
-                                            <div class="text-base font-semibold leading-snug" title="{{ value }}">
-                                            {% if value.lower().startswith('error:') %}
-                                                <span class="text-red-500">Error</span>
-                                            {% else %}
-                                                <span class="text-white">{{ value }}</span>
+                            {# Ports #}
+                            <div class="drawer-row">
+                                <span class="drawer-label">Ports</span>
+                                <span class="drawer-value">
+                                    {% set _has_ports = (entry.published_ports and entry.published_ports|length > 0) or (entry.exposed_ports and entry.exposed_ports|length > 0) %}
+                                    {% if _has_ports %}
+                                        {% set ns = namespace(pub_set=[]) %}
+                                        {% if entry.published_ports %}
+                                          <div class="space-y-0.5">
+                                          {% for p in entry.published_ports %}
+                                            {% set _host_part = (p.host_ip ~ ':' if p.host_ip and p.host_ip != '0.0.0.0' else '') ~ p.host_port|string %}
+                                            <div class="text-xs font-mono">{{ p.container_port }}/{{ p.protocol }} → {{ _host_part }}</div>
+                                            {% set ns.pub_set = ns.pub_set + [p.container_port|string ~ '/' ~ p.protocol] %}
+                                          {% endfor %}
+                                          </div>
+                                        {% endif %}
+                                        {% if entry.exposed_ports %}
+                                          {% set _extras = [] %}
+                                          {% for ep in entry.exposed_ports %}
+                                            {% if ep not in ns.pub_set %}
+                                              {% set _extras = _extras + [ep] %}
                                             {% endif %}
-                                            </div>
+                                          {% endfor %}
+                                          {% if _extras %}
+                                            <div class="text-xs font-mono text-gray-400 mt-0.5">{{ _extras | join(', ') }} (exposed)</div>
+                                          {% endif %}
+                                        {% endif %}
+                                    {% else %}
+                                        <em class="text-gray-500">Not reported</em>
+                                    {% endif %}
+                                </span>
+                            </div>
 
+                            {# Exposure observations #}
+                            {% if entry.exposures %}
+                            <div class="drawer-row">
+                                <span class="drawer-label">Exposure</span>
+                                <span class="drawer-value">
+                                    <div class="space-y-1">
+                                    {% for ex in entry.exposures %}
+                                        <div class="text-xs">
+                                            <code class="text-blue-400 mr-1">{{ ex.layer }}</code>
+                                            {% if ex.hostname %}{{ ex.hostname }}{% endif %}
+                                            {% if ex.path_prefix %}<span class="text-gray-400">{{ ex.path_prefix }}</span>{% endif %}
+                                            {% if ex.tls %}<span class="ml-1 bg-gray-700 text-gray-300 px-1 rounded text-[0.65rem]"><i class="ti ti-lock" aria-hidden="true"></i> TLS</span>{% endif %}
+                                            {% if ex.auth and ex.auth not in ['none', ''] %}<span class="ml-1 bg-gray-700 text-gray-300 px-1 rounded text-[0.65rem]"><i class="ti ti-key" aria-hidden="true"></i> {{ ex.auth }}</span>{% endif %}
                                         </div>
                                     {% endfor %}
-                                </div>
-                            {% else %}
-                                <div class="text-gray-400 italic">No widget data available.</div>
+                                    </div>
+                                </span>
+                            </div>
                             {% endif %}
-                        </div>
-                    {% endif %}
 
-                    
+                            {# Widget data #}
+                            {% if entry.widget_id %}
+                              {% set widget_data = widget_values.get(entry.widget_id) %}
+                              {% if widget_data %}
+                              <div class="drawer-row">
+                                  <span class="drawer-label">Widget</span>
+                                  <span class="drawer-value">
+                                      {% set allowed_fields = widget_fields.get(entry.widget_id, []) %}
+                                      <div class="drawer-widget-grid">
+                                          {% for field, value in widget_data.items() if field in allowed_fields %}
+                                              <div class="drawer-widget-card">
+                                                  <div class="drawer-widget-label">{{ field.replace('_', ' ') | title }}</div>
+                                                  <div class="drawer-widget-value">
+                                                      {% if value.lower().startswith('error:') %}
+                                                          <span class="text-red-500">Error</span>
+                                                      {% else %}
+                                                          {{ value }}
+                                                      {% endif %}
+                                                  </div>
+                                              </div>
+                                          {% endfor %}
+                                      </div>
+                                  </span>
+                              </div>
+                              {% endif %}
+                            {% endif %}
 
-                
-                   
-                        
-                    </div>
+                            <hr class="drawer-divider">
+
+                            {# Action row #}
+                            <div class="drawer-actions">
+                                <a href="{{ url_for('dashboard.edit_entry', id=entry.id, ref=request.full_path) }}"
+                                   class="drawer-btn drawer-btn-edit">
+                                    <i class="ti ti-edit" aria-hidden="true"></i> Edit
+                                </a>
+
+                                <button class="drawer-btn drawer-btn-delete"
+                                        data-entry-id="{{ entry.id }}"
+                                        data-container-name="{{ entry.container_name }}"
+                                        data-is-static="{{ 'true' if entry.is_static else 'false' }}">
+                                    <i class="ti ti-trash" aria-hidden="true"></i> Delete
+                                </button>
+
+                                {% if _has_dozzle %}
+                                <div class="drawer-tools-wrap">
+                                    <button class="drawer-btn drawer-btn-tools">
+                                        <i class="ti ti-tools" aria-hidden="true"></i> Tools
+                                    </button>
+                                    <div class="tools-dropdown">
+                                        <a href="{{ _dozzle_base }}/container/{{ _dozzle_id[:12] }}" target="_blank">
+                                            <i class="ti ti-terminal-2" aria-hidden="true"></i> Dozzle logs
+                                        </a>
+                                    </div>
+                                </div>
+                                {% endif %}
+                            </div>
+
+                        </div>{# /tile-drawer #}
+
+                    </div>{# /tile-wrapper #}
                 {% else %}
-                    <p>No entries in this group.</p> {% endfor %}
+                    <p>No entries in this group.</p>
+                {% endfor %}
             </div>
         {% endfor %}
     {% else %}
         <p style="text-align: center; margin-top: 30px;">No service entries found or no groups to display based on current selection.</p>
     {% endif %}
-{% endblock %}
-
-{% block extra_scripts %}
-<script>
-let secondsSinceRefresh = 0;
-let refreshInterval = 60;
-
-document.addEventListener('DOMContentLoaded', function () {
-  // Tile Clickability
-  const tiles = document.querySelectorAll('.tile');
-  tiles.forEach(tile => {
-    const internalUrl = tile.dataset.internalurl;
-    const externalUrl = tile.dataset.externalurl;
-    if (internalUrl || externalUrl) {
-      tile.style.cursor = 'pointer';
-      tile.addEventListener('click', function (event) {
-        if (event.target.closest('a.status-button') || event.target.closest('a.dozzle-direct-link')) return;
-        if (internalUrl) {
-          window.open(internalUrl, '_blank');
-        } else if (externalUrl) {
-          window.open(externalUrl, '_blank');
-        }
-      });
-    }
-  });
-
-  // Collapse Toggle Persistence
-  const headers = document.querySelectorAll('.group-header');
-  headers.forEach(header => {
-    const groupName = header.dataset.group;
-    const container = document.querySelector(`[data-group-container="${groupName}"]`);
-    const icon = header.querySelector('.toggle-icon');
-    const isCollapsed = localStorage.getItem(`groupCollapse:${groupName}`) === 'true';
-    if (isCollapsed) {
-      container.style.display = 'none';
-      icon.textContent = '▸';
-    }
-    header.addEventListener('click', () => {
-      const collapsed = container.style.display === 'none';
-      container.style.display = collapsed ? '' : 'none';
-      icon.textContent = collapsed ? '▾' : '▸';
-      localStorage.setItem(`groupCollapse:${groupName}`, (!collapsed).toString());
-    });
-  });
-
-  // Auto Refresh Logic
-  const refreshLabel = document.getElementById('refreshTimer');
-  const refreshDropdown = document.getElementById('refreshInterval');
-  const savedInterval = localStorage.getItem('refreshInterval');
-  if (savedInterval !== null) {
-    refreshInterval = parseInt(savedInterval);
-    if (refreshDropdown) refreshDropdown.value = savedInterval;
-  }
-  if (refreshDropdown) {
-    refreshDropdown.addEventListener('change', function () {
-      refreshInterval = parseInt(this.value);
-      localStorage.setItem('refreshInterval', this.value);
-    });
-  }
-// Widget info
-    const toggleWidgets = document.getElementById('toggleWidgets');
-    const widgetBoxes = document.querySelectorAll('.widget-box');
-    const storedWidgetPref = localStorage.getItem('showWidgets') === 'true';
-    // Set initial toggle state
-    if (toggleWidgets) {
-        toggleWidgets.checked = storedWidgetPref;
-        widgetBoxes.forEach(box => {
-            box.classList.toggle('hidden', !storedWidgetPref);
-        });
-
-        toggleWidgets.addEventListener('change', () => {
-            const show = toggleWidgets.checked;
-            widgetBoxes.forEach(box => {
-                box.classList.toggle('hidden', !show);
-            });
-            localStorage.setItem('showWidgets', show);
-        });
-    }
-
-
-  setInterval(() => {
-    secondsSinceRefresh++;
-    if (refreshLabel) {
-      const m = Math.floor(secondsSinceRefresh / 60);
-      const s = secondsSinceRefresh % 60;
-      refreshLabel.textContent = `Refreshed ${m > 0 ? m + 'm ' : ''}${s}s ago`;
-    }
-
-    if (refreshInterval > 0 && secondsSinceRefresh >= refreshInterval) {
-      window.location.reload();
-    }
-  }, 1000);
-
-    // Filter tiles by input text
-    const filterInput = document.getElementById('filterInput');
-    if (filterInput) {
-      filterInput.addEventListener('input', function () {
-        const filter = this.value.toLowerCase();
-        const tiles = document.querySelectorAll('.tile-wrapper');
-
-        tiles.forEach(tile => {
-          const containerName = tile.querySelector('.container-name')?.textContent?.toLowerCase() || '';
-          const hostName = tile.querySelector('.host-name')?.textContent?.toLowerCase() || '';
-          const groupHeader = tile.closest('[data-group-container]')?.previousElementSibling?.textContent?.toLowerCase() || '';
-
-          const matches = containerName.includes(filter) ||
-                          hostName.includes(filter) ||
-                          groupHeader.includes(filter);
-
-          tile.style.display = matches ? '' : 'none';
-        });
-      });
-    }
-});
-
-</script>
 {% endblock %}


### PR DESCRIPTION
## [0.6.1] — 2026-05-16

UI overhaul, part 1: Tiled dashboard redesign, per-tile expand drawer,
icon vocabulary shared across Tiled and Dashboard, inline CSS/JS
extracted to shared static files, Compact tab-highlight fix.

### Added

- **Per-tile expand drawer on Tiled.** Clicking the chevron on any tile
  drops a panel anchored to the tile (overlay, not inline reflow). Drawer
  shows host, internal/external URLs with health status, Docker status and
  image tag, networks, ports, exposure observations, and widget data.
  Action row at the bottom has Edit, Delete, and (when Dozzle is
  configured) a Tools popover with a Dozzle link.
- **Pencil-icon edit affordance** on Tiled tiles (status icon row) and
  Dashboard table Actions column. Both navigate to `/edit/<id>?ref=<path>`.
- **Tabler Icons** (v3.34.0) loaded via cdnjs CDN. Outline set only.
  Used for all new icons in this release.
- **Tools popover in the Tiled drawer.** Seeded with the Dozzle link.
  Renders only when at least one tool is available.

### Changed

- **Tiled dashboard tile redesign.** Host line removed from the tile
  face (now in the drawer). Status area replaced with icon row:
  `ti-home` (internal URL), `ti-world` (external URL),
  `ti-brand-docker` (Docker), plus widget indicator, Dozzle, edit
  pencil, and expand chevron. Colors: green 2xx, amber SSL/stale, red
  non-2xx or bad, gray not-configured.
- **Exposure badges** (Tiled, Dashboard, edit page) now use Tabler
  icons `ti-lock` / `ti-key` instead of 🔒 / 🔑 emoji.
- **Dashboard table status column** now uses icon-and-label pills
  sharing the Tiled icon vocabulary (`ti-home`, `ti-world`,
  `ti-brand-docker`).
- **Dashboard Tools column** uses `ti-terminal-2` instead of the
  Dozzle SVG image.
- **Per-template inline CSS and JS extracted** to
  `static/css/dashboard.css` and `static/js/dashboard.js`. All three
  dashboard views now share these files. Hybrid Tailwind-utilities-
  plus-custom-CSS approach formalized; no frontend build step.

### Removed

- **"Show Widgets" filter-bar toggle on Tiled.** Widget data is now
  accessible via the per-tile expand drawer.

### Fixed

- **Compact tab failed to highlight** in the nav. The missing
  `{% set active_tab = 'compact' %}` declaration has been added.