### PR TITLE
fix: restore toggleRestoreSource lost in v0.6.1 JS extraction (v0.6.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] — 2026-05-16
+
+### Fixed
+
+- **Restore-from-upload broken on /settings.** The `toggleRestoreSource`
+  function was dropped during the v0.6.1 inline-JS extraction, leaving
+  `#file-upload-section` permanently hidden with no way to select a local
+  YAML backup file. The function has been restored to the settings template.
+- **No filename feedback after selecting an upload file.** The
+  `#restore_file_input` change event now updates `#file-name-display` with
+  the selected filename so operators can confirm their file choice before
+  submitting.
+
 ## [0.6.1] — 2026-05-16
 
 UI overhaul, part 1: Tiled dashboard redesign, per-tile expand drawer,

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -14,6 +14,7 @@
 | 0.4     | 2026-05-13 | Exposure interpreter mechanism folded into v0.6.0 rather than shipping as a separate v0.7.0 release. §9 expanded with §§9.4–9.8 (wire contract, synthesizer, URL provenance, per-interpreter settings, badges + headless rendering). New §5.4 documents the v0.6.0 schema additions for the interpreter (`service_exposure`, two URL source columns on `service_entry`, `setting` table). §10 retired (no scoped features for the next release). |
 | 0.5     | 2026-05-14 | v0.6.0 released. The originally-planned v0.5.x (view controls + helper consolidation), v0.6.0 (compat shim removal + capture columns), and v0.7.0 (exposure interpreter) work shipped together as a single v0.6.0 release. Former §8 (v0.5.x planning) folded into the new §8 (Delivered in v0.6.0). §6.2 D2 marked Resolved in v0.6.0. Cross-repo coordination (now §10.2) collapsed the v0.3.2 / v0.4.0 notifier split into a single notifier v0.4.0 pairing. Later sections renumbered: §10/§11/§12 → §9/§10/§11. |
 | 0.6     | 2026-05-16 | v0.6.1 delivered. UI overhaul part 1: tiled drawer, Tabler Icons v3.34.0 icon vocabulary, per-template inline CSS/JS extracted to shared static files. §9 added. |
+| 0.7     | 2026-05-16 | v0.6.2 hotfix. Restored `toggleRestoreSource` dropped during v0.6.1 JS extraction; wired file-input change event for filename feedback on /settings restore. |
 
 ---
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -507,6 +507,28 @@
 
 {% block extra_scripts %}
 <script>
+  function toggleRestoreSource(value) {
+    const serverSection = document.getElementById('server-file-selector-section');
+    const uploadSection = document.getElementById('file-upload-section');
+    if (value === 'upload') {
+      serverSection.classList.add('hidden');
+      uploadSection.classList.remove('hidden');
+    } else {
+      uploadSection.classList.add('hidden');
+      serverSection.classList.remove('hidden');
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    const fileInput = document.getElementById('restore_file_input');
+    const fileDisplay = document.getElementById('file-name-display');
+    if (fileInput && fileDisplay) {
+      fileInput.addEventListener('change', function () {
+        fileDisplay.textContent = this.files.length > 0 ? this.files[0].name : 'YAML up to 10MB';
+      });
+    }
+  });
+
   function showSection(id) {
     document.querySelectorAll('.section').forEach(s => s.classList.add('hidden'));
     document.getElementById(`section-${id}`).classList.remove('hidden');


### PR DESCRIPTION
The function was removed when inline JS was moved to shared static files, permanently hiding #file-upload-section on /settings. Also wires #restore_file_input change event to update #file-name-display with the selected filename before submit.

Bumps to v0.6.2. CHANGELOG and PRD updated.