### PR TITLE
feat: v0.6.3 — orphan sweep, inline-style cleanup, what's new popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] — 2026-05-17
+
+Foundations for "UI overhaul, part 2": orphan handler sweep,
+inline-style cleanup completing the v0.6.1 CSS extraction, and a
+"what's new" popup that fires automatically after each version upgrade.
+
+### Added
+
+- **"What's new" popup.** After upgrading STD, operators see a modal on
+  their next page load showing the changelog entries for every version
+  since the one they last acknowledged. Dismissal writes the current
+  version to `localStorage` and closes. New API route
+  `GET /api/v1/changelog?since=<version>` parses `CHANGELOG.md`
+  server-side and returns the relevant sections as rendered HTML.
+- **`markdown` package** added to `requirements.txt` to support
+  server-side rendering of changelog sections.
+
+### Changed
+
+- **Inline `<style>` blocks removed** from `templates/edit_entry.html`
+  and `templates/settings.html`. The v0.6.1 CSS extraction is now
+  complete — `.form-input`, `.form-checkbox`, `.btn-primary`, and
+  `.btn-secondary` are defined only in `static/css/dashboard.css`.
+  `.btn-primary` background normalized from `#4299e1` to
+  `var(--color-accent)` (`#3b82f6`) — minor visible difference on
+  the edit and add pages.
+- **`version_info` is now injected globally** into every template that
+  extends `base.html` via the app context processor (previously only
+  passed explicitly to the settings page). Required by the changelog
+  popup to read the current version.
+
+### Fixed
+
+- **`toggleGroupMode` unreachable from inline `onclick=`** on the
+  edit-entry and add-entry pages. The function was scoped inside a
+  `DOMContentLoaded` closure, making it invisible to inline handler
+  attributes. Hoisted to module scope in both templates.
+
 ## [0.6.2] — 2026-05-16
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,34 +47,16 @@
 
 ## Build Status
 
-Current shipped release: **v0.5.0** (latest tag on `main`)
-
-Next release target: **v0.6.0** — bundled sunset + capture +
-interpreter release. Three threads of work shipping together:
-
-1. **Sunset** of `/api/register` and the legacy-key compat shim.
-2. **Network/ports capture** — three new JSON columns on
-   `service_entry` populated by notifier v0.3.2+.
-3. **Exposure interpreter mechanism** — wire contract for
-   interpreter outputs (`exposure_observations` field on the
-   register payload), new `service_exposure` table, URL synthesizer,
-   URL provenance tracking (`*_source` columns), DB-stored
-   per-interpreter direction settings (new `setting` table +
-   `settings_store.py`), exposure badges on the tile/table
-   dashboards, and headless rendering for services with no URL or
-   exposure evidence.
-
-Notifier coordination:
-- Notifier v0.3.0+ is required for any producer (canonical keys).
-- Notifier v0.3.2 ships **after** STD v0.6.0 and populates the
-  capture columns.
-- Notifier v0.4.0 ships **after** STD v0.6.0 and populates
-  `exposure_observations` via YAML interpreters.
+Current shipped release: **v0.6.2** (latest tag on `main`)
 
 Status:
+
 - v0.5.0 — cleanup release (split, pydantic, retention, indexes): DONE
-- v0.5.x — view controls + grouping helper consolidation: folded into v0.6.0
-- v0.6.0 — sunset + capture + interpreter: IN PROGRESS (on dev)
+- v0.6.0 — sunset + capture + interpreter: DONE
+- v0.6.1 — UI overhaul part 1 (tiled redesign, drawer, shared CSS/JS): DONE
+- v0.6.2 — hotfix: restore `toggleRestoreSource`, upload filename feedback: DONE
+- v0.6.3 — UI overhaul part 2 foundations (orphan sweep, inline-style cleanup, what's new popup): IN PROGRESS (on dev)
+- v0.6.4 / v0.6.5 — UI overhaul part 2 (scoped separately, fresh sessions): TBD
 - v0.7.0+ — TBD (no scoped features at present)
 
 ## Git Workflow

--- a/app.py
+++ b/app.py
@@ -122,8 +122,11 @@ def create_app():
     os.makedirs(IMAGE_DIR, exist_ok=True)
 
     @app.context_processor
-    def inject_now():
-        return {'now': datetime.now}
+    def inject_globals():
+        return {
+            'now': datetime.now,
+            'version_info': app.config['VERSION_INFO'],
+        }
 
     @app.template_filter('time_since')
     def time_since(dt):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ PyYAML
 apscheduler
 alembic
 pydantic>=2,<3
+markdown

--- a/routes_dashboard.py
+++ b/routes_dashboard.py
@@ -16,15 +16,18 @@ the query params and hands them to the helper.
 
 import logging
 import os
+import re
 from datetime import datetime
 from urllib.parse import urlparse
 
+import markdown as _md
 import requests
 import yaml
 from flask import (
     Blueprint,
     current_app,
     flash,
+    jsonify,
     make_response,
     redirect,
     render_template,
@@ -52,6 +55,58 @@ from view_helpers import (
 logger = logging.getLogger(__name__)
 
 dashboard_bp = Blueprint("dashboard", __name__)
+
+# Module-level cache for parsed changelog sections. CHANGELOG.md is baked into
+# the image at build time and never changes at runtime, so parse once on first
+# request and reuse.
+_changelog_cache = None
+_CHANGELOG_SECTION_RE = re.compile(
+    r'^## \[(\d+\.\d+\.\d+)\] — (\d{4}-\d{2}-\d{2})',
+    re.MULTILINE,
+)
+
+
+def _parse_version(s):
+    try:
+        return tuple(int(x) for x in s.split('.'))
+    except (ValueError, AttributeError):
+        return None
+
+
+def _get_changelog_sections():
+    global _changelog_cache
+    if _changelog_cache is not None:
+        return _changelog_cache
+
+    try:
+        # CHANGELOG.md is at the same directory as this file in both the
+        # container (COPY . . puts everything under /app) and local dev.
+        changelog_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'CHANGELOG.md')
+        if not os.path.exists(changelog_path):
+            _changelog_cache = []
+            return _changelog_cache
+        with open(changelog_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+    except Exception:
+        _changelog_cache = []
+        return _changelog_cache
+
+    matches = list(_CHANGELOG_SECTION_RE.finditer(content))
+    sections = []
+    for i, match in enumerate(matches):
+        version = match.group(1)
+        date = match.group(2)
+        body_start = match.end()
+        body_end = matches[i + 1].start() if i + 1 < len(matches) else len(content)
+        body = content[body_start:body_end].strip()
+        sections.append({
+            'version': version,
+            'date': date,
+            'html': _md.markdown(body),
+        })
+
+    _changelog_cache = sections
+    return _changelog_cache
 
 
 # Helper to check if flash messages are already present (to avoid duplicates)
@@ -919,3 +974,33 @@ def edit_entry(id):
                            groups=groups,
                            available_widgets=available_widgets,
                            selected_widget=selected_widget)
+
+
+@dashboard_bp.route('/api/v1/changelog')
+@login_required
+def changelog_api():
+    """Return parsed CHANGELOG.md sections as JSON.
+
+    ?since=<version>  — return only sections newer than this version (exclusive).
+    Omitted / invalid since → return only the current version's section.
+    since >= current → empty sections array (downgrade case).
+    """
+    current = current_app.config['VERSION_INFO'].get('version', 'unknown')
+    since_raw = request.args.get('since', '').strip()
+    since_tuple = _parse_version(since_raw)
+    current_tuple = _parse_version(current)
+
+    sections = _get_changelog_sections()
+
+    if since_tuple is None:
+        result = [s for s in sections if s['version'] == current]
+    elif current_tuple is not None and since_tuple >= current_tuple:
+        result = []
+    else:
+        result = [
+            s for s in sections
+            if _parse_version(s['version']) is not None
+            and _parse_version(s['version']) > since_tuple
+        ]
+
+    return jsonify({'current': current, 'sections': result})

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -65,6 +65,23 @@
   outline: none;
   box-shadow: 0 0 0 2px var(--color-accent-dim);
 }
+.form-checkbox {
+  color: var(--color-accent);
+  background-color: var(--color-bg-surface);
+  border-color: #4a5568;
+}
+
+/* ── Page-level action buttons ────────────────────────────── */
+.btn-primary {
+  background-color: var(--color-accent);
+  color: white;
+}
+.btn-primary:hover { background-color: #3182ce; }
+.btn-secondary {
+  background-color: #4a5568;
+  color: white;
+}
+.btn-secondary:hover { background-color: #2d3748; }
 
 /* ── Exposure badges ──────────────────────────────────────── */
 .exposure-badges {
@@ -499,4 +516,149 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* ── Changelog "What's new" modal ────────────────────────── */
+.changelog-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.changelog-modal.hidden { display: none; }
+
+.changelog-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.changelog-modal-panel {
+  position: relative;
+  z-index: 501;
+  width: min(640px, calc(100vw - 32px));
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-tile);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+}
+
+.changelog-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+.changelog-modal-header h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+.changelog-modal-close {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+  transition: color 0.15s ease;
+}
+.changelog-modal-close:hover { color: var(--color-text-secondary); }
+
+.changelog-modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 20px;
+}
+
+.changelog-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 12px 20px;
+  border-top: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+.changelog-modal-dismiss {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.78rem;
+  padding: 4px 14px;
+  border-radius: 4px;
+  border: 1px solid #facc15;
+  background: none;
+  color: #facc15;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+.changelog-modal-dismiss:hover {
+  background-color: #facc15;
+  color: #000;
+}
+
+/* Version section headers inside the modal body */
+.changelog-version-block { margin-bottom: 20px; }
+.changelog-version-block:last-child { margin-bottom: 0; }
+.changelog-version-header {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-accent);
+  margin: 0 0 8px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+/* Rendered markdown inside modal body */
+.changelog-modal-body h3 {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  margin: 12px 0 4px;
+}
+.changelog-modal-body h4 {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  margin: 8px 0 4px;
+}
+.changelog-modal-body ul {
+  margin: 4px 0 8px 16px;
+  list-style: disc;
+}
+.changelog-modal-body li {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+  margin-bottom: 2px;
+}
+.changelog-modal-body li strong {
+  color: var(--color-text-primary);
+}
+.changelog-modal-body p {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+  margin: 4px 0 8px;
+}
+.changelog-modal-body code {
+  font-size: 0.75rem;
+  background-color: var(--color-bg-raised);
+  border-radius: 3px;
+  padding: 1px 4px;
+  color: #93c5fd;
+}
+
+@media (max-width: 480px) {
+  .changelog-modal-body { padding: 12px 14px; }
+  .changelog-modal-header,
+  .changelog-modal-footer { padding: 10px 14px; }
 }

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -274,11 +274,74 @@
     });
   };
 
+  /* ── Changelog "What's new" modal ───────────────────── */
+  function initChangelogModal() {
+    const modal   = document.getElementById('changelog-modal');
+    if (!modal) return;
+
+    const currentVersion = document.body.dataset.stdVersion || '';
+    if (!currentVersion || currentVersion === 'unknown') return;
+
+    const STORAGE_KEY = 'std:lastSeenVersion';
+    const lastSeen    = localStorage.getItem(STORAGE_KEY);
+
+    function showModal(sections) {
+      if (!sections || sections.length === 0) return;
+
+      const body = document.getElementById('changelog-content');
+      body.innerHTML = sections.map(s => `
+        <div class="changelog-version-block">
+          <p class="changelog-version-header">v${s.version} — ${s.date}</p>
+          ${s.html}
+        </div>
+      `).join('');
+
+      modal.classList.remove('hidden');
+      document.addEventListener('keydown', onEsc);
+    }
+
+    function dismiss() {
+      localStorage.setItem(STORAGE_KEY, currentVersion);
+      modal.classList.add('hidden');
+      document.removeEventListener('keydown', onEsc);
+    }
+
+    function onEsc(e) {
+      if (e.key === 'Escape') dismiss();
+    }
+
+    modal.querySelector('.changelog-modal-close').addEventListener('click', dismiss);
+    modal.querySelector('.changelog-modal-dismiss').addEventListener('click', dismiss);
+    modal.querySelector('.changelog-modal-backdrop').addEventListener('click', dismiss);
+
+    if (lastSeen === null) {
+      fetch('/api/v1/changelog')
+        .then(r => r.json())
+        .then(data => showModal(data.sections))
+        .catch(() => {});
+    } else if (lastSeen === currentVersion) {
+      // No change — don't pop.
+    } else {
+      fetch(`/api/v1/changelog?since=${encodeURIComponent(lastSeen)}`)
+        .then(r => r.json())
+        .then(data => {
+          if (!data.sections || data.sections.length === 0) {
+            // Downgrade case or already current — silently update.
+            localStorage.setItem(STORAGE_KEY, currentVersion);
+          } else {
+            showModal(data.sections);
+          }
+        })
+        .catch(() => {});
+    }
+  }
+
   /* ── Bootstrap ───────────────────────────────────────── */
   document.addEventListener('DOMContentLoaded', function () {
     initRefresh();
     initViewControls();
     initFilter();
+    initChangelogModal();
 
     const view = document.body.dataset.view;
     if (view === 'tiled') {

--- a/templates/add_entry.html
+++ b/templates/add_entry.html
@@ -105,17 +105,14 @@
 {% endblock %}
 {% block extra_scripts %}
 <script>
+  function toggleGroupMode() {
+    const useExisting = document.getElementById('select_existing').checked;
+    document.getElementById('group_name_existing').classList.toggle('hidden', !useExisting);
+    document.getElementById('group_name_new').classList.toggle('hidden', useExisting);
+  }
+
   document.addEventListener('DOMContentLoaded', function () {
-    function toggleGroupMode() {
-      const useExisting = document.getElementById('select_existing').checked;
-      document.getElementById('group_name_existing').classList.toggle('hidden', !useExisting);
-      document.getElementById('group_name_new').classList.toggle('hidden', useExisting);
-    }
-
-    // Assign once on load
     toggleGroupMode();
-
-    // Bind event listeners (in case onclick inline isn't used)
     document.getElementById('select_existing').addEventListener('change', toggleGroupMode);
     document.getElementById('add_new').addEventListener('change', toggleGroupMode);
   });

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,8 @@
 </head>
 
 <body class="bg-gray-900 text-gray-200 min-h-screen px-4 py-8 font-sans"
-      data-view="{% block body_data_view %}{% endblock %}">
+      data-view="{% block body_data_view %}{% endblock %}"
+      data-std-version="{{ version_info.version | default('unknown') }}">
   <div class="max-w-screen-2xl mx-auto">
   <!-- Header -->
     <div class="text-xl font-semibold text-white mb-4">Service Tracker Dashboard</div>
@@ -48,6 +49,7 @@
     </main>
   </div>
 
+  {% include 'partials/changelog_modal.html' %}
   {% block extra_scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/edit_entry.html
+++ b/templates/edit_entry.html
@@ -1,47 +1,5 @@
 {% extends "base.html" %}
 
-{% block head %}
-<style>
-  .form-input {
-    background-color: #1f2937;
-    color: #e2e8f0;
-    border: 1px solid #4a5568;
-    padding: 0.625rem 1rem;
-    border-radius: 0.5rem;
-    font-size: 0.875rem;
-    width: 100%;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
-  }
-  .form-input::placeholder {
-    color: #94a3b8;
-  }
-  .form-input:focus {
-    border-color: #3b82f6;
-    outline: none;
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
-  }
-  .form-checkbox {
-    color: #3b82f6;
-    background-color: #1f2937;
-    border-color: #4a5568;
-  }
-  .btn-primary {
-    background-color: #4299e1;
-    color: white;
-  }
-  .btn-primary:hover {
-    background-color: #3182ce;
-  }
-  .btn-secondary {
-    background-color: #4a5568;
-    color: white;
-  }
-  .btn-secondary:hover {
-    background-color: #2d3748;
-  }
-</style>
-{% endblock %}
-
 {% block content %}
 <div class="flex justify-center px-4 py-8">
   <div class="w-full max-w-3xl">
@@ -276,68 +234,68 @@
 {% endblock %}
 {% block extra_scripts %}
 <script>
-document.addEventListener('DOMContentLoaded', function () {
-  // === Widget Field Logic ===
-  const widgetSelect = document.getElementById('widget_name');
-  const container = document.getElementById('widget_fields_container');
-
-  function loadWidgetFields(widgetName, preselected = []) {
-    container.innerHTML = '';
-    if (!widgetName || widgetName === 'none') return;
-
-    fetch(`/widget_config/${widgetName}`)
-      .then(response => response.json())
-      .then(fields => {
-        if (!Array.isArray(fields)) return;
-
-        fields.forEach(field => {
-          const checkbox = document.createElement('input');
-          checkbox.type = 'checkbox';
-          checkbox.name = 'widget_fields';
-          checkbox.value = field.key;
-          checkbox.className = 'mr-2';
-          if (preselected.includes(field.key)) checkbox.checked = true;
-
-          const label = document.createElement('label');
-          label.className = 'block mb-2 text-sm text-white';
-          label.innerHTML = `<strong>${field.label}</strong><br><span class="text-gray-400">${field.description}</span>`;
-          label.prepend(checkbox);
-
-          container.appendChild(label);
-        });
-      })
-      .catch(err => console.error("❌ Error loading widget config:", err));
-  }
-
-  if (widgetSelect) {
-    widgetSelect.addEventListener('change', function () {
-      loadWidgetFields(this.value);
-    });
-
-    {% if selected_widget and selected_widget.widget_name %}
-    loadWidgetFields(
-      '{{ selected_widget.widget_name }}',
-      {{ selected_widget.widget_fields | tojson | safe }}
-    );
-    {% endif %}
-  }
-
-  // === Group Toggle Logic ===
   function toggleGroupMode() {
     const useExisting = document.getElementById('select_existing').checked;
     document.getElementById('group_id_existing').classList.toggle('hidden', !useExisting);
     document.getElementById('group_name_new').classList.toggle('hidden', useExisting);
   }
 
-  const selectExisting = document.getElementById('select_existing');
-  const addNew = document.getElementById('add_new');
+  document.addEventListener('DOMContentLoaded', function () {
+    // === Widget Field Logic ===
+    const widgetSelect = document.getElementById('widget_name');
+    const container = document.getElementById('widget_fields_container');
 
-  if (selectExisting && addNew) {
-    toggleGroupMode();
-    selectExisting.addEventListener('change', toggleGroupMode);
-    addNew.addEventListener('change', toggleGroupMode);
-  }
-});
+    function loadWidgetFields(widgetName, preselected = []) {
+      container.innerHTML = '';
+      if (!widgetName || widgetName === 'none') return;
+
+      fetch(`/widget_config/${widgetName}`)
+        .then(response => response.json())
+        .then(fields => {
+          if (!Array.isArray(fields)) return;
+
+          fields.forEach(field => {
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.name = 'widget_fields';
+            checkbox.value = field.key;
+            checkbox.className = 'mr-2';
+            if (preselected.includes(field.key)) checkbox.checked = true;
+
+            const label = document.createElement('label');
+            label.className = 'block mb-2 text-sm text-white';
+            label.innerHTML = `<strong>${field.label}</strong><br><span class="text-gray-400">${field.description}</span>`;
+            label.prepend(checkbox);
+
+            container.appendChild(label);
+          });
+        })
+        .catch(err => console.error("❌ Error loading widget config:", err));
+    }
+
+    if (widgetSelect) {
+      widgetSelect.addEventListener('change', function () {
+        loadWidgetFields(this.value);
+      });
+
+      {% if selected_widget and selected_widget.widget_name %}
+      loadWidgetFields(
+        '{{ selected_widget.widget_name }}',
+        {{ selected_widget.widget_fields | tojson | safe }}
+      );
+      {% endif %}
+    }
+
+    // === Group Toggle Logic ===
+    const selectExisting = document.getElementById('select_existing');
+    const addNew = document.getElementById('add_new');
+
+    if (selectExisting && addNew) {
+      toggleGroupMode();
+      selectExisting.addEventListener('change', toggleGroupMode);
+      addNew.addEventListener('change', toggleGroupMode);
+    }
+  });
 </script>
 {% endblock %}
 

--- a/templates/partials/changelog_modal.html
+++ b/templates/partials/changelog_modal.html
@@ -1,0 +1,15 @@
+<div id="changelog-modal" class="changelog-modal hidden" role="dialog" aria-modal="true" aria-labelledby="changelog-modal-title">
+  <div class="changelog-modal-backdrop"></div>
+  <div class="changelog-modal-panel">
+    <div class="changelog-modal-header">
+      <h2 id="changelog-modal-title">What's new in STD</h2>
+      <button class="changelog-modal-close" aria-label="Close">&times;</button>
+    </div>
+    <div class="changelog-modal-body" id="changelog-content">
+      <!-- populated by JS -->
+    </div>
+    <div class="changelog-modal-footer">
+      <button class="changelog-modal-dismiss">Got it</button>
+    </div>
+  </div>
+</div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -2,26 +2,6 @@
 
 {% block head %}
   <title>Settings</title>
-  <style>
-    .form-input {
-      background-color: #1f2937;
-      color: #e2e8f0;
-      border: 1px solid #4a5568;
-      padding: 0.625rem 1rem;
-      border-radius: 0.5rem;
-      font-size: 0.875rem;
-      width: 100%;
-      transition: border-color 0.2s ease, box-shadow 0.2s ease;
-    }
-    .form-input::placeholder {
-      color: #94a3b8;
-    }
-    .form-input:focus {
-      border-color: #3b82f6;
-      outline: none;
-      box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
-    }
-  </style>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Task 1 — Orphan handler sweep:
- toggleGroupMode was scoped inside DOMContentLoaded in edit_entry.html and add_entry.html, making it unreachable from inline onclick= attrs. Hoisted to module scope in both templates.

Task 2 — Inline <style> block removal:
- edit_entry.html: removed inline block defining .form-input, .form-checkbox, .btn-primary, .btn-secondary.
- settings.html: removed inline block defining .form-input.
- All four classes now defined only in static/css/dashboard.css. .btn-primary background normalized from #4299e1 to var(--color-accent). v0.6.1 CSS extraction is now complete.

Task 3 — What's new popup:
- New GET /api/v1/changelog?since=<version> route parses CHANGELOG.md and returns version sections as rendered HTML (module-level cache).
- markdown added to requirements.txt for server-side rendering.
- New templates/partials/changelog_modal.html included in base.html.
- initChangelogModal() added to dashboard.js; fires on every page load, compares localStorage std:lastSeenVersion to current version.
- version_info injected globally via context processor (was settings-only).
- data-std-version attribute added to <body> in base.html.