### PR TITLE
v0.6.4 merge to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4] — 2026-05-17
+
+UI overhaul, part 2 (release 2 of 3): mobile usability and tile restructure.
+The filter bar now collapses cleanly on phones, tile status icons split into two
+rows so container names stop truncating, and the drawer scrolls its tile into
+view when you tap to expand it.
+
+### Added
+
+- **Mobile filter bar.** Below 640 px the filter bar collapses to just the
+  free-text filter plus a "View options" toggle button. Tapping the toggle
+  reveals group-by, sort, Show URL-less, auto-refresh, and total count in a
+  vertical panel. Tapping outside or pressing Esc collapses it again. Above
+  640 px the filter bar is unchanged.
+- **Drawer scrolls into view on mobile.** When you tap the chevron on a Tiled
+  tile near the bottom of the viewport, the page smoothly scrolls the tile to
+  the top so the drawer has room to expand below it. Only triggers below 768 px
+  wide — desktop drawers are unaffected.
+- **Stack row in the tile drawer.** When a service has a stack name, the Tiled
+  drawer now shows it immediately after Host. Saves a trip to the edit page
+  when grouped by host.
+
+### Changed
+
+- **Tile status icons now render in two rows.** The single-row icon layout was
+  truncating container names aggressively when all affordances were present.
+  Status icons (internal URL, external URL, Docker, widget) now occupy the top
+  row; action icons (Dozzle, edit pencil, expand chevron) occupy the bottom
+  row. Container names get back the horizontal space they need. Tiles are
+  roughly 20 % taller as a result.
+- **Larger touch targets on mobile.** Tile status icons and drawer action
+  buttons have bigger hit boxes below 640 px — same visual size, more
+  forgiving for fingers. Desktop appearance unchanged.
+- **`icon-sep` separator removed.** The two-row icon layout replaces it
+  semantically.
+
 ## [0.6.3] — 2026-05-17
 
 Foundations for "UI overhaul, part 2": orphan handler sweep,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@
 
 ## Build Status
 
-Current shipped release: **v0.6.2** (latest tag on `main`)
+Current shipped release: **v0.6.3** (latest tag on `main`)
 
 Status:
 
@@ -55,8 +55,9 @@ Status:
 - v0.6.0 — sunset + capture + interpreter: DONE
 - v0.6.1 — UI overhaul part 1 (tiled redesign, drawer, shared CSS/JS): DONE
 - v0.6.2 — hotfix: restore `toggleRestoreSource`, upload filename feedback: DONE
-- v0.6.3 — UI overhaul part 2 foundations (orphan sweep, inline-style cleanup, what's new popup): IN PROGRESS (on dev)
-- v0.6.4 / v0.6.5 — UI overhaul part 2 (scoped separately, fresh sessions): TBD
+- v0.6.3 — UI overhaul part 2 foundations (orphan sweep, inline-style cleanup, what's new popup): DONE
+- v0.6.4 — UI overhaul part 2: mobile usability + tile icon restructure: IN PROGRESS (on dev)
+- v0.6.5 — UI overhaul part 2 (edit page polish + universal delete popover): TBD
 - v0.7.0+ — TBD (no scoped features at present)
 
 ## Git Workflow

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -221,12 +221,19 @@
   font-size: 0.95em;
 }
 
-/* ── Status icon row (new tiled design) ───────────────────── */
+/* ── Status icon block (two rows: status top, actions bottom) ─ */
 .tile-status-row {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  flex-shrink: 0;
+  align-items: flex-end;
+}
+.tile-icon-row {
   display: flex;
   align-items: center;
   gap: 4px;
-  flex-shrink: 0;
+  justify-content: flex-end;
 }
 .tile-status-row .status-icon {
   font-size: 16px;
@@ -255,16 +262,6 @@
 .status-icon-bad  { color: var(--color-status-bad); }
 .status-icon-muted{ color: var(--color-status-muted); }
 .status-icon-blue { color: var(--color-status-blue); }
-
-/* 1px vertical separator between status and action icons */
-.icon-sep {
-  display: inline-block;
-  width: 1px;
-  height: 14px;
-  background-color: var(--color-border-input);
-  margin: 0 2px;
-  flex-shrink: 0;
-}
 
 /* Chevron button */
 .tile-chevron {
@@ -518,6 +515,44 @@
   text-overflow: ellipsis;
 }
 
+/* ── Filter bar mobile collapse ──────────────────────────── */
+.fb-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  background: none;
+  border: 1px solid var(--color-border-input);
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.fb-toggle:hover {
+  color: var(--color-text-secondary);
+  border-color: var(--color-text-muted);
+}
+.fb-toggle.is-open {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+@media (max-width: 639px) {
+  .fb-panel {
+    display: none;
+  }
+  .fb-panel.fb-panel-open {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding-top: 10px;
+    border-top: 1px solid var(--color-border);
+  }
+}
+
 /* ── Changelog "What's new" modal ────────────────────────── */
 .changelog-modal {
   position: fixed;
@@ -661,4 +696,14 @@
   .changelog-modal-body { padding: 12px 14px; }
   .changelog-modal-header,
   .changelog-modal-footer { padding: 10px 14px; }
+}
+
+/* ── Mobile touch targets (< 640px) ──────────────────────── */
+@media (max-width: 639px) {
+  .tile-status-row .status-icon {
+    padding: 8px;
+  }
+  .drawer-btn {
+    padding: 8px 14px;
+  }
 }

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -180,6 +180,10 @@
         this.setAttribute('aria-expanded', 'true');
         currentOpenDrawer = drawer;
         currentOpenTile   = tile;
+
+        if (window.innerWidth < 768) {
+          wrapper.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
       });
     });
 
@@ -274,6 +278,37 @@
     });
   };
 
+  /* ── Filter bar mobile collapse ─────────────────────── */
+  function initFilterBarMobile() {
+    const toggle = document.getElementById('filterBarToggle');
+    const panel  = document.getElementById('filterBarPanel');
+    if (!toggle || !panel) return;
+
+    function setOpen(open) {
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+      toggle.classList.toggle('is-open', open);
+      panel.classList.toggle('fb-panel-open', open);
+    }
+
+    toggle.addEventListener('click', function (e) {
+      e.stopPropagation();
+      setOpen(!panel.classList.contains('fb-panel-open'));
+    });
+
+    document.addEventListener('click', function (e) {
+      if (!panel.classList.contains('fb-panel-open')) return;
+      if (!e.target.closest('#filterBarToggle') && !e.target.closest('#filterBarPanel')) {
+        setOpen(false);
+      }
+    });
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && panel.classList.contains('fb-panel-open')) {
+        setOpen(false);
+      }
+    });
+  }
+
   /* ── Changelog "What's new" modal ───────────────────── */
   function initChangelogModal() {
     const modal   = document.getElementById('changelog-modal');
@@ -341,6 +376,7 @@
     initRefresh();
     initViewControls();
     initFilter();
+    initFilterBarMobile();
     initChangelogModal();
 
     const view = document.body.dataset.view;

--- a/templates/partials/filter_bar.html
+++ b/templates/partials/filter_bar.html
@@ -1,43 +1,62 @@
-<div class="flex flex-col sm:flex-row sm:justify-between gap-4 mb-4 items-start sm:items-center">
-  <div class="flex gap-4 items-center flex-wrap">
-    <input id="filterInput" type="text" placeholder="Filter by Group, Container, or Stack" class="bg-gray-800 border border-gray-600 px-3 py-1 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 flex-grow sm:flex-none" />
+<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between sm:gap-4 gap-2 mb-4">
 
-    <label for="groupBySelect" class="text-sm text-gray-300">Group by:</label>
-    <select id="groupBySelect" data-param="group_by" class="view-control bg-gray-800 border border-gray-600 px-3 py-1 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 text-white">
-      <option value="group" {% if group_by == 'group' %}selected{% endif %}>Group</option>
-      <option value="stack" {% if group_by == 'stack' %}selected{% endif %}>Stack</option>
-      <option value="host" {% if group_by == 'host' %}selected{% endif %}>Host</option>
-    </select>
+  {# Always-visible row: filter input + mobile toggle #}
+  <div class="flex items-center gap-2">
+    <input id="filterInput" type="text" placeholder="Filter by Group, Container, or Stack"
+           class="bg-gray-800 border border-gray-600 px-3 py-1 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 flex-1 sm:flex-none" />
 
-    <label for="sortInGroupSelect" class="text-sm text-gray-300">Sort:</label>
-    <select id="sortInGroupSelect" data-param="sort_in_group" class="view-control bg-gray-800 border border-gray-600 px-3 py-1 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 text-white">
-      <option value="alphabetical" {% if sort_in_group == 'alphabetical' %}selected{% endif %}>Alphabetical</option>
-      <option value="priority" {% if sort_in_group == 'priority' %}selected{% endif %}>Priority</option>
-    </select>
-
-    <label class="flex items-center gap-2 text-sm text-gray-300 select-none cursor-pointer">
-      <input type="checkbox" id="showUrllessToggle" data-param="show_urlless"
-             class="view-control h-4 w-4 rounded border-gray-600 bg-gray-800 text-blue-600 focus:ring-blue-500"
-             {% if show_urlless %}checked{% endif %}>
-      Show URL-less
-    </label>
-
-    <span class="text-sm text-gray-400 ml-2">
-      Total Services:
-      {{ total_entries if total_entries is defined else 'N/A' }}
-    </span>
+    <button id="filterBarToggle"
+            class="fb-toggle sm:hidden"
+            aria-expanded="false"
+            aria-label="View options">
+      <i class="ti ti-adjustments" aria-hidden="true"></i>
+      <span>View options</span>
+    </button>
   </div>
 
-  <div class="flex gap-2 items-center mt-2 sm:mt-0">
-    <label for="refreshInterval" class="text-sm text-gray-400">Auto Refresh:</label>
-    <select id="refreshInterval" class="bg-gray-800 border border-gray-600 px-2 py-1 rounded text-sm text-white">
-      <option value="30">30s</option>
-      <option value="60">1m</option>
-      <option value="300">5m</option>
-      <option value="600">10m</option>
-      <option value="0">Never</option>
-    </select>
+  {# Collapsible controls panel: hidden on mobile until toggled, always shown on sm+ #}
+  <div id="filterBarPanel" class="fb-panel sm:flex sm:items-center sm:gap-4 sm:flex-wrap sm:justify-between">
 
-    <div id="refreshTimer" class="text-sm text-gray-400 cursor-pointer" onclick="window.location.reload()">Refreshed just now</div>
+    <div class="flex gap-4 items-center flex-wrap">
+      <label for="groupBySelect" class="text-sm text-gray-300">Group by:</label>
+      <select id="groupBySelect" data-param="group_by" class="view-control bg-gray-800 border border-gray-600 px-3 py-1 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 text-white">
+        <option value="group" {% if group_by == 'group' %}selected{% endif %}>Group</option>
+        <option value="stack" {% if group_by == 'stack' %}selected{% endif %}>Stack</option>
+        <option value="host" {% if group_by == 'host' %}selected{% endif %}>Host</option>
+      </select>
+
+      <label for="sortInGroupSelect" class="text-sm text-gray-300">Sort:</label>
+      <select id="sortInGroupSelect" data-param="sort_in_group" class="view-control bg-gray-800 border border-gray-600 px-3 py-1 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 text-white">
+        <option value="alphabetical" {% if sort_in_group == 'alphabetical' %}selected{% endif %}>Alphabetical</option>
+        <option value="priority" {% if sort_in_group == 'priority' %}selected{% endif %}>Priority</option>
+      </select>
+
+      <label class="flex items-center gap-2 text-sm text-gray-300 select-none cursor-pointer">
+        <input type="checkbox" id="showUrllessToggle" data-param="show_urlless"
+               class="view-control h-4 w-4 rounded border-gray-600 bg-gray-800 text-blue-600 focus:ring-blue-500"
+               {% if show_urlless %}checked{% endif %}>
+        Show URL-less
+      </label>
+
+      <span class="text-sm text-gray-400">
+        Total Services:
+        {{ total_entries if total_entries is defined else 'N/A' }}
+      </span>
+    </div>
+
+    <div class="flex gap-2 items-center">
+      <label for="refreshInterval" class="text-sm text-gray-400">Auto Refresh:</label>
+      <select id="refreshInterval" class="bg-gray-800 border border-gray-600 px-2 py-1 rounded text-sm text-white">
+        <option value="30">30s</option>
+        <option value="60">1m</option>
+        <option value="300">5m</option>
+        <option value="600">10m</option>
+        <option value="0">Never</option>
+      </select>
+
+      <div id="refreshTimer" class="text-sm text-gray-400 cursor-pointer" onclick="window.location.reload()">Refreshed just now</div>
+    </div>
+
   </div>
+
 </div>

--- a/templates/tiled_dash.html
+++ b/templates/tiled_dash.html
@@ -131,84 +131,87 @@
                                 {% endwith %}
                             </div>
 
-                            {# Status icon row #}
+                            {# Status icon block: two rows (status top, actions bottom) #}
                             <div class="tile-status-row">
 
-                                {# Internal URL icon #}
-                                {% if _int_href %}
-                                    <a href="{{ _int_href }}" target="_blank"
-                                       class="status-icon {{ _int_class }}"
-                                       title="{{ _int_tooltip }}"
-                                       onclick="event.stopPropagation()">
-                                        <i class="ti ti-home" aria-hidden="true"></i>
-                                    </a>
-                                {% else %}
-                                    <span class="status-icon {{ _int_class }}" title="{{ _int_tooltip }}">
-                                        <i class="ti ti-home" aria-hidden="true"></i>
-                                    </span>
-                                {% endif %}
+                                <div class="tile-icon-row tile-icon-row-status">
+                                    {# Internal URL icon #}
+                                    {% if _int_href %}
+                                        <a href="{{ _int_href }}" target="_blank"
+                                           class="status-icon {{ _int_class }}"
+                                           title="{{ _int_tooltip }}"
+                                           onclick="event.stopPropagation()">
+                                            <i class="ti ti-home" aria-hidden="true"></i>
+                                        </a>
+                                    {% else %}
+                                        <span class="status-icon {{ _int_class }}" title="{{ _int_tooltip }}">
+                                            <i class="ti ti-home" aria-hidden="true"></i>
+                                        </span>
+                                    {% endif %}
 
-                                {# External URL icon #}
-                                {% if _ext_href %}
-                                    <a href="{{ _ext_href }}" target="_blank"
-                                       class="status-icon {{ _ext_class }}"
-                                       title="{{ _ext_tooltip }}"
-                                       onclick="event.stopPropagation()">
-                                        <i class="ti ti-world" aria-hidden="true"></i>
-                                    </a>
-                                {% else %}
-                                    <span class="status-icon {{ _ext_class }}" title="{{ _ext_tooltip }}">
-                                        <i class="ti ti-world" aria-hidden="true"></i>
-                                    </span>
-                                {% endif %}
+                                    {# External URL icon #}
+                                    {% if _ext_href %}
+                                        <a href="{{ _ext_href }}" target="_blank"
+                                           class="status-icon {{ _ext_class }}"
+                                           title="{{ _ext_tooltip }}"
+                                           onclick="event.stopPropagation()">
+                                            <i class="ti ti-world" aria-hidden="true"></i>
+                                        </a>
+                                    {% else %}
+                                        <span class="status-icon {{ _ext_class }}" title="{{ _ext_tooltip }}">
+                                            <i class="ti ti-world" aria-hidden="true"></i>
+                                        </span>
+                                    {% endif %}
 
-                                {# Docker status icon (dynamic entries only) #}
-                                {% if not entry.is_static %}
-                                    <span class="status-icon {{ _docker_class }}" title="{{ _docker_tooltip }}">
-                                        <i class="ti ti-brand-docker" aria-hidden="true"></i>
-                                    </span>
-                                {% else %}
-                                    <span class="status-icon status-icon-muted" title="Static entry">
-                                        <i class="ti ti-brand-docker" aria-hidden="true"></i>
-                                    </span>
-                                {% endif %}
+                                    {# Docker status icon (dynamic entries only) #}
+                                    {% if not entry.is_static %}
+                                        <span class="status-icon {{ _docker_class }}" title="{{ _docker_tooltip }}">
+                                            <i class="ti ti-brand-docker" aria-hidden="true"></i>
+                                        </span>
+                                    {% else %}
+                                        <span class="status-icon status-icon-muted" title="Static entry">
+                                            <i class="ti ti-brand-docker" aria-hidden="true"></i>
+                                        </span>
+                                    {% endif %}
 
-                                <span class="icon-sep" aria-hidden="true"></span>
+                                    {# Widget indicator #}
+                                    {% if entry.widget_id %}
+                                        <span class="status-icon status-icon-blue" title="Widget data — click chevron to expand">
+                                            <i class="ti ti-chart-line" aria-hidden="true"></i>
+                                        </span>
+                                    {% endif %}
+                                </div>{# /tile-icon-row-status #}
 
-                                {# Widget indicator #}
-                                {% if entry.widget_id %}
-                                    <span class="status-icon status-icon-blue" title="Widget data — click chevron to expand">
-                                        <i class="ti ti-chart-line" aria-hidden="true"></i>
-                                    </span>
-                                {% endif %}
+                                <div class="tile-icon-row tile-icon-row-actions">
+                                    {# Dozzle icon #}
+                                    {% if _has_dozzle %}
+                                        <a href="{{ _dozzle_base }}/container/{{ _dozzle_id[:12] }}"
+                                           target="_blank"
+                                           class="status-icon status-icon-muted"
+                                           title="Open logs in Dozzle ({{ _dozzle_id[:12] }})"
+                                           onclick="event.stopPropagation()">
+                                            <i class="ti ti-terminal-2" aria-hidden="true"></i>
+                                        </a>
+                                    {% endif %}
 
-                                {# Dozzle icon #}
-                                {% if _has_dozzle %}
-                                    <a href="{{ _dozzle_base }}/container/{{ _dozzle_id[:12] }}"
-                                       target="_blank"
+                                    {# Edit icon #}
+                                    <a href="{{ url_for('dashboard.edit_entry', id=entry.id, ref=request.full_path) }}"
                                        class="status-icon status-icon-muted"
-                                       title="Open logs in Dozzle ({{ _dozzle_id[:12] }})"
+                                       title="Edit"
                                        onclick="event.stopPropagation()">
-                                        <i class="ti ti-terminal-2" aria-hidden="true"></i>
+                                        <i class="ti ti-edit" aria-hidden="true"></i>
                                     </a>
-                                {% endif %}
 
-                                {# Edit icon #}
-                                <a href="{{ url_for('dashboard.edit_entry', id=entry.id, ref=request.full_path) }}"
-                                   class="status-icon status-icon-muted"
-                                   title="Edit"
-                                   onclick="event.stopPropagation()">
-                                    <i class="ti ti-edit" aria-hidden="true"></i>
-                                </a>
+                                    {# Expand chevron #}
+                                    <button class="tile-chevron"
+                                            data-drawer="drawer-{{ entry.id }}"
+                                            aria-expanded="false"
+                                            aria-label="Expand details for {{ entry.container_name }}"
+                                            title="Expand details">
+                                        <i class="ti ti-chevron-down" aria-hidden="true"></i>
+                                    </button>
+                                </div>{# /tile-icon-row-actions #}
 
-                                {# Expand chevron #}
-                                <button class="tile-chevron"
-                                        data-drawer="drawer-{{ entry.id }}"
-                                        aria-expanded="false"
-                                        aria-label="Expand details for {{ entry.container_name }}"
-                                        title="Expand details">
-                                    <i class="ti ti-chevron-down" aria-hidden="true"></i>
-                                </button>
                             </div>{# /tile-status-row #}
 
                         </div>{# /tile #}
@@ -223,6 +226,14 @@
                                 <span class="drawer-label">Host</span>
                                 <span class="drawer-value">{{ entry.host }}</span>
                             </div>
+
+                            {# Stack #}
+                            {% if entry.stack_name %}
+                            <div class="drawer-row">
+                                <span class="drawer-label">Stack</span>
+                                <span class="drawer-value">{{ entry.stack_name }}</span>
+                            </div>
+                            {% endif %}
 
                             {# Internal URL #}
                             {% if entry.internalurl %}


### PR DESCRIPTION
## Summary

- **Tile icon block split into two rows.** Status icons (home, world,
  docker, widget) on top; action icons (Dozzle, edit, chevron) on
  bottom. Frees horizontal space so container names stop truncating.
  `icon-sep` element and its CSS rule removed.
- **Mobile filter bar collapse.** Below 640 px the filter bar shows
  only the free-text input plus a "View options" toggle. All other
  controls (group-by, sort, URL-less, auto-refresh, timer) collapse
  into a panel that opens/closes on tap, outside-click, or Esc.
  Desktop layout unchanged.
- **Drawer scroll-into-view on mobile.** Tapping the chevron on a tile
  near the bottom of the viewport smoothly scrolls the tile to the
  top so the drawer has room to expand. Only fires below 768 px.
- **Stack row in the tile drawer.** Shown immediately after Host when
  `stack_name` is set. Conditional — no row if empty.
- **Larger mobile touch targets.** Tile status icons and drawer action
  buttons get bigger hit boxes below 640 px via `@media` — visual
  size unchanged on desktop.