### PR TITLE
feat: v0.6.5 — edit page polish, universal delete, widget modal, refr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.5] — 2026-05-17
+
+UI overhaul, part 2 (release 3 of 3): edit page polish, a universal delete
+pattern, click-to-view widget data, and an auto-refresh that knows not to wipe
+out your work while you're looking at it.
+
+### Added
+
+- **Trash icon on Tiled tiles and Dashboard rows.** One click deletes a dynamic
+  entry, with a small inline confirm popover anchored to the icon. Static
+  (Locked) entries show a lock icon in the same slot instead — they can only be
+  deleted from the edit page, which is the deliberate path for protected entries.
+- **Widget data modal.** Clicking the chart icon on a tile now opens a modal
+  showing just that service's widget data. Faster than expanding the full drawer,
+  especially on mobile. The chevron drawer still works as before.
+- **Auto-refresh pauses while you're interacting.** Open a drawer, the widget
+  modal, or the changelog popup, and the page won't refresh out from under you.
+  The refresh timer shows "Refresh paused" while interaction is active and
+  resumes (counter reset to 0) when you close everything.
+
+### Changed
+
+- **Edit page visual polish.** Tighter input padding and border-radius, section
+  headings (Identity / URLs & Health / Grouping & Display / Widget), tighter
+  spacing within sections and looser between, muted helper text. URL fields now
+  group their health-check checkbox inline below the input instead of floating
+  it to the side. The "Select Existing / Add New" group selector is now a
+  tab-style toggle instead of bullet radios.
+- **Universal delete UI.** All delete affordances — drawer Delete button, edit
+  page Delete button, and the new trash icons — use the same small inline
+  popover with a Confirm button. The typed-name confirmation form is gone;
+  static entries are protected by being deletable only from the edit page.
+- **Lock icon replaces 🔒 emoji on Dashboard rows.** Consistent visual language
+  with the new Tiled lock indicator. Same meaning: "this entry is locked from
+  notifier updates; delete from the edit page."
+- **Drawer Delete button hidden for static entries.** The tile-level lock icon
+  signals the constraint; the drawer no longer duplicates it.
+
+### Removed
+
+- **Danger Zone section on the edit page.** Replaced by a single Delete button
+  at the bottom of the form, using the new popover.
+
 ## [0.6.4] — 2026-05-17
 
 UI overhaul, part 2 (release 2 of 3): mobile usability and tile restructure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@
 
 ## Build Status
 
-Current shipped release: **v0.6.3** (latest tag on `main`)
+Current shipped release: **v0.6.4** (latest tag on `main`)
 
 Status:
 
@@ -56,8 +56,8 @@ Status:
 - v0.6.1 — UI overhaul part 1 (tiled redesign, drawer, shared CSS/JS): DONE
 - v0.6.2 — hotfix: restore `toggleRestoreSource`, upload filename feedback: DONE
 - v0.6.3 — UI overhaul part 2 foundations (orphan sweep, inline-style cleanup, what's new popup): DONE
-- v0.6.4 — UI overhaul part 2: mobile usability + tile icon restructure: IN PROGRESS (on dev)
-- v0.6.5 — UI overhaul part 2 (edit page polish + universal delete popover): TBD
+- v0.6.4 — UI overhaul part 2: mobile usability + tile icon restructure: DONE
+- v0.6.5 — UI overhaul part 2 (edit page polish, universal delete, widget modal, refresh pause): IN PROGRESS (on dev)
 - v0.7.0+ — TBD (no scoped features at present)
 
 ## Git Workflow

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ through the web UI or directly via API.
 
 ## What It Does
 
-- Three dashboard views (table, tiled, compact). Tiled view shows each service as a tile with a per-tile expand drawer for full host, URL, Docker, network, port, exposure, and widget detail. Icons use [Tabler Icons](https://tabler.io/icons) v3.34.0 (loaded via CDN).
+- Three dashboard views (table, tiled, compact). Tiled view shows each service as a tile with a per-tile expand drawer for full host, URL, Docker, network, port, exposure, and widget detail. Icons use [Tabler Icons](https://tabler.io/icons) v3.34.0 (loaded via CDN). Clicking the chart icon on a tile opens a widget-data modal without expanding the full drawer.
 - **Dashboard view controls (v0.6.0+).** A `Group by` axis selector
   (`group` / `stack` / `host`) and a `Show URL-less` filter render
   above the service grid on all three views. State is URL-driven, so
@@ -52,7 +52,7 @@ through the web UI or directly via API.
 - Register endpoint for pushing container metadata from external tools.
 - SQLite backing store, file-based, no external DB server.
 - Daily YAML backups with retention.
-- Manual add / edit / delete through the web UI.
+- Manual add / edit / delete through the web UI. Tiled tiles and Dashboard rows have a one-click trash icon with an inline confirm popover. Static (Locked) entries show a lock icon and can only be deleted from the edit page.
 - Optional Dozzle log link integration.
 - Local user accounts with session-based auth.
 - Per-entry sort priority within groups; grouping and group sort.

--- a/routes_dashboard.py
+++ b/routes_dashboard.py
@@ -976,6 +976,30 @@ def edit_entry(id):
                            selected_widget=selected_widget)
 
 
+@dashboard_bp.route('/api/v1/entries/<int:id>/delete', methods=['POST'])
+@login_required
+@is_admin_required
+def delete_entry_json(id):
+    """JSON delete endpoint for JS-triggered deletes (tile trash icon, drawer delete button).
+
+    Returns {ok: true} on success. The caller is responsible for DOM cleanup or redirect.
+    """
+    entry = ServiceEntry.query.get_or_404(id)
+
+    if entry.widget_id:
+        other_services = ServiceEntry.query.filter(
+            ServiceEntry.widget_id == entry.widget_id,
+            ServiceEntry.id != entry.id
+        ).count()
+        if other_services == 0:
+            WidgetValue.query.filter_by(widget_id=entry.widget_id).delete()
+            Widget.query.filter_by(id=entry.widget_id).delete()
+
+    db.session.delete(entry)
+    db.session.commit()
+    return jsonify({'ok': True})
+
+
 @dashboard_bp.route('/api/v1/changelog')
 @login_required
 def changelog_api():

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -53,8 +53,8 @@
   background-color: var(--color-bg-surface);
   color: var(--color-text-secondary);
   border: 1px solid #4a5568;
-  padding: 0.625rem 1rem;
-  border-radius: var(--radius-input);
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
   font-size: 0.875rem;
   width: 100%;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
@@ -706,4 +706,218 @@
   .drawer-btn {
     padding: 8px 14px;
   }
+}
+
+/* ── Delete popover ───────────────────────────────────────── */
+.delete-popover {
+  position: fixed;
+  z-index: 300;
+  max-width: 280px;
+  background-color: var(--color-bg-raised);
+  border: 1px solid var(--color-border-input);
+  border-radius: var(--radius-tile);
+  padding: 10px 14px 12px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.65);
+}
+.delete-popover.hidden { display: none; }
+.delete-popover-message {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  margin-bottom: 10px;
+}
+.delete-popover-message strong { color: var(--color-text-primary); }
+.delete-popover-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+.delete-popover-cancel {
+  font-size: 0.78rem;
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border-input);
+  background: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.delete-popover-cancel:hover {
+  color: var(--color-text-secondary);
+  border-color: var(--color-text-muted);
+}
+.delete-popover-confirm {
+  font-size: 0.78rem;
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--color-status-bad);
+  background-color: var(--color-status-bad);
+  color: #fff;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+.delete-popover-confirm:hover { opacity: 0.85; }
+@media (max-width: 639px) {
+  .delete-popover { max-width: calc(100vw - 32px); }
+  .delete-popover-cancel,
+  .delete-popover-confirm { padding: 8px 14px; }
+}
+
+/* ── Trash / lock icons on tiles and rows ─────────────────── */
+.status-icon-trash { color: var(--color-status-muted); }
+.tile-status-row button.status-icon-trash:hover {
+  color: var(--color-status-bad);
+  opacity: 1;
+}
+
+/* ── Widget data modal ────────────────────────────────────── */
+.widget-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.widget-modal.hidden { display: none; }
+
+.widget-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.widget-modal-panel {
+  position: relative;
+  z-index: 501;
+  width: min(480px, calc(100vw - 32px));
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-tile);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+}
+
+.widget-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+.widget-modal-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+.widget-modal-close {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px;
+  min-width: 32px;
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s ease;
+}
+.widget-modal-close:hover { color: var(--color-text-secondary); }
+
+.widget-modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 18px;
+}
+.widget-modal-body .drawer-widget-grid {
+  grid-template-columns: repeat(3, 1fr);
+  margin-top: 0;
+}
+.widget-modal-no-data {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  font-style: italic;
+  text-align: center;
+  padding: 20px 0;
+}
+
+@media (max-width: 480px) {
+  .widget-modal-header,
+  .widget-modal-body { padding: 10px 14px; }
+  .widget-modal-close { min-width: 44px; min-height: 44px; font-size: 1.6rem; }
+  .widget-modal-body .drawer-widget-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 360px) {
+  .widget-modal-body .drawer-widget-grid { grid-template-columns: 1fr; }
+}
+
+/* ── Edit page section headings ───────────────────────────── */
+.edit-section-heading {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  margin-top: 1.75rem;
+  margin-bottom: 0.75rem;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--color-border);
+  letter-spacing: 0.03em;
+}
+.edit-section-heading:first-child { margin-top: 0; }
+
+.edit-section-fields { display: flex; flex-direction: column; gap: 0.75rem; }
+
+.edit-helper {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  font-style: italic;
+  margin-top: 3px;
+}
+
+/* ── Group mode tab toggle ────────────────────────────────── */
+.group-mode-tabs {
+  display: inline-flex;
+  border: 1px solid var(--color-border-input);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.group-tab {
+  display: inline-block;
+  padding: 5px 16px;
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  background: none;
+  transition: background-color 0.15s ease, color 0.15s ease;
+  user-select: none;
+  line-height: 1.4;
+}
+.group-tab + .group-tab { border-left: 1px solid var(--color-border-input); }
+
+#select_existing:checked + .group-tab { background-color: var(--color-accent); color: #fff; }
+#add_new:checked + .group-tab { background-color: var(--color-accent); color: #fff; }
+
+/* ── Edit page delete button ──────────────────────────────── */
+.edit-delete-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.82rem;
+  padding: 5px 14px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border-input);
+  background: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+.edit-delete-btn:hover {
+  border-color: var(--color-status-bad);
+  color: var(--color-status-bad);
 }

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -2,7 +2,8 @@
    Service Tracker Dashboard — shared JavaScript
    Covers: auto-refresh, group-collapse, view-controls,
    filter-input, tiled tile-click, tile drawers, tools popover,
-   dashboard group-toggle, clipboard copy.
+   dashboard group-toggle, clipboard copy, delete popover,
+   widget modal, refresh-pause while interacting.
    ============================================================ */
 
 (function () {
@@ -11,6 +12,17 @@
   /* ── Auto-refresh ─────────────────────────────────────── */
   let secondsSinceRefresh = 0;
   let refreshInterval = 60;
+
+  function isInteracting() {
+    if (currentOpenDrawer) return true;
+    const widgetModal    = document.getElementById('widget-modal');
+    const changelogModal = document.getElementById('changelog-modal');
+    const deletePopover  = document.getElementById('delete-popover');
+    if (widgetModal    && !widgetModal.classList.contains('hidden'))    return true;
+    if (changelogModal && !changelogModal.classList.contains('hidden')) return true;
+    if (deletePopover  && !deletePopover.classList.contains('hidden'))  return true;
+    return false;
+  }
 
   function initRefresh() {
     const refreshLabel    = document.getElementById('refreshTimer');
@@ -27,6 +39,10 @@
       });
     }
     setInterval(() => {
+      if (isInteracting()) {
+        if (refreshLabel) refreshLabel.textContent = 'Refresh paused (drawer open)';
+        return;
+      }
       secondsSinceRefresh++;
       if (refreshLabel) {
         const m = Math.floor(secondsSinceRefresh / 60);
@@ -155,6 +171,8 @@
       }
       currentOpenDrawer = null;
       currentOpenTile   = null;
+      // Reset refresh timer so next cycle starts fresh
+      secondsSinceRefresh = 0;
     }
   }
 
@@ -216,6 +234,83 @@
     });
   }
 
+  /* ── Delete popover ──────────────────────────────────── */
+  let _deleteOutsideHandler = null;
+  let _deleteEscHandler     = null;
+
+  function hideDeletePopover() {
+    const pop = document.getElementById('delete-popover');
+    if (!pop) return;
+    pop.classList.add('hidden');
+    if (_deleteOutsideHandler) {
+      document.removeEventListener('click', _deleteOutsideHandler, true);
+      _deleteOutsideHandler = null;
+    }
+    if (_deleteEscHandler) {
+      document.removeEventListener('keydown', _deleteEscHandler);
+      _deleteEscHandler = null;
+    }
+  }
+
+  function showDeletePopover(triggerEl, containerName, onConfirm) {
+    hideDeletePopover();
+
+    const pop = document.getElementById('delete-popover');
+    if (!pop) return;
+
+    pop.querySelector('.delete-popover-target').textContent = containerName;
+    pop.classList.remove('hidden');
+
+    // Position: fixed, relative to viewport
+    const rect = triggerEl.getBoundingClientRect();
+    const popW = Math.min(280, window.innerWidth - 32);
+    pop.style.maxWidth = popW + 'px';
+    pop.style.width    = 'auto';
+
+    // Default below; shift above if not enough room
+    const popH = pop.offsetHeight;
+    let top  = rect.bottom + 4;
+    if (top + popH > window.innerHeight - 8) top = rect.top - popH - 4;
+    if (top < 8) top = 8;
+
+    // Align left edge with trigger, shift left if it clips right edge
+    let left = rect.left;
+    if (left + popW > window.innerWidth - 8) left = window.innerWidth - popW - 8;
+    if (left < 8) left = 8;
+
+    pop.style.top  = top  + 'px';
+    pop.style.left = left + 'px';
+
+    // Wire buttons (clone to drop any previous listeners)
+    const oldConfirm = pop.querySelector('.delete-popover-confirm');
+    const oldCancel  = pop.querySelector('.delete-popover-cancel');
+    const newConfirm = oldConfirm.cloneNode(true);
+    const newCancel  = oldCancel.cloneNode(true);
+    oldConfirm.replaceWith(newConfirm);
+    oldCancel.replaceWith(newCancel);
+
+    newConfirm.addEventListener('click', () => { hideDeletePopover(); onConfirm(); });
+    newCancel.addEventListener('click',  hideDeletePopover);
+
+    // Click-outside (capture phase so it fires before other handlers)
+    setTimeout(() => {
+      _deleteOutsideHandler = function (e) {
+        if (!pop.contains(e.target) && e.target !== triggerEl) hideDeletePopover();
+      };
+      document.addEventListener('click', _deleteOutsideHandler, true);
+    }, 0);
+
+    _deleteEscHandler = function (e) { if (e.key === 'Escape') hideDeletePopover(); };
+    document.addEventListener('keydown', _deleteEscHandler);
+  }
+
+  /* Shared fetch-delete helper used by tile, drawer, and dashboard row. */
+  function fetchDelete(entryId, onSuccess, onError) {
+    fetch(`/api/v1/entries/${entryId}/delete`, { method: 'POST' })
+      .then(r => r.ok ? onSuccess() : onError())
+      .catch(onError);
+  }
+
   /* ── Tiled drawer: delete action ────────────────────── */
   function initDrawerDelete() {
     document.querySelectorAll('.drawer-btn-delete').forEach(btn => {
@@ -223,37 +318,49 @@
         e.stopPropagation();
         const entryId       = this.dataset.entryId;
         const containerName = this.dataset.containerName;
-        const isStatic      = this.dataset.isStatic === 'true';
+        showDeletePopover(this, containerName, () => {
+          fetchDelete(entryId, () => {
+            // Remove the tile-wrapper from the DOM
+            const drawer  = document.getElementById(`drawer-${entryId}`);
+            const wrapper = drawer ? drawer.closest('.tile-wrapper') : null;
+            if (wrapper) wrapper.remove();
+            closeCurrentDrawer();
+          }, () => alert('Delete failed. Please try again.'));
+        });
+      });
+    });
+  }
 
-        let confirmed = false;
-        if (isStatic) {
-          const typed = prompt(
-            `STATIC ENTRY: Type the container name to confirm deletion.\n\n` +
-            `Container: "${containerName}"\n\nThis cannot be undone.`
-          );
-          confirmed = (typed === containerName);
-        } else {
-          confirmed = confirm(`Delete "${containerName}"? This cannot be undone.`);
-        }
+  /* ── Tiled: trash icon on tile ───────────────────────── */
+  function initTileTrash() {
+    document.querySelectorAll('.tile-trash-btn').forEach(btn => {
+      btn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        const entryId       = this.dataset.entryId;
+        const containerName = this.dataset.containerName;
+        showDeletePopover(this, containerName, () => {
+          fetchDelete(entryId, () => {
+            const wrapper = this.closest('.tile-wrapper');
+            if (wrapper) wrapper.remove();
+          }, () => alert('Delete failed. Please try again.'));
+        });
+      });
+    });
+  }
 
-        if (!confirmed) return;
-
-        const form = document.createElement('form');
-        form.method = 'POST';
-        form.action = `/edit/${entryId}`;
-
-        const addField = (name, value) => {
-          const input = document.createElement('input');
-          input.type  = 'hidden';
-          input.name  = name;
-          input.value = value;
-          form.appendChild(input);
-        };
-        addField('delete', '1');
-        addField('delete_confirmation', containerName);
-
-        document.body.appendChild(form);
-        form.submit();
+  /* ── Dashboard: trash icon on row ────────────────────── */
+  function initDashboardTrash() {
+    document.querySelectorAll('.row-trash-btn').forEach(btn => {
+      btn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        const entryId       = this.dataset.entryId;
+        const containerName = this.dataset.containerName;
+        showDeletePopover(this, containerName, () => {
+          fetchDelete(entryId, () => {
+            const row = this.closest('tr');
+            if (row) row.remove();
+          }, () => alert('Delete failed. Please try again.'));
+        });
       });
     });
   }
@@ -309,6 +416,53 @@
     });
   }
 
+  /* ── Widget modal ────────────────────────────────────── */
+  function initWidgetModal() {
+    const modal    = document.getElementById('widget-modal');
+    const content  = document.getElementById('widget-modal-content');
+    const titleEl  = modal ? modal.querySelector('.widget-modal-title') : null;
+    const closeBtn = modal ? modal.querySelector('.widget-modal-close') : null;
+    const backdrop = modal ? modal.querySelector('.widget-modal-backdrop') : null;
+    if (!modal) return;
+
+    function showWidgetModal(containerName, widgetGrid) {
+      titleEl.textContent = containerName;
+      content.innerHTML = '';
+      if (widgetGrid && widgetGrid.children.length > 0) {
+        content.appendChild(widgetGrid.cloneNode(true));
+      } else {
+        const msg = document.createElement('p');
+        msg.className = 'widget-modal-no-data';
+        msg.textContent = 'No widget data available yet.';
+        content.appendChild(msg);
+      }
+      modal.classList.remove('hidden');
+      document.addEventListener('keydown', onModalEsc);
+    }
+
+    function hideWidgetModal() {
+      modal.classList.add('hidden');
+      secondsSinceRefresh = 0;
+      document.removeEventListener('keydown', onModalEsc);
+    }
+
+    function onModalEsc(e) { if (e.key === 'Escape') hideWidgetModal(); }
+
+    if (closeBtn) closeBtn.addEventListener('click', hideWidgetModal);
+    if (backdrop) backdrop.addEventListener('click', hideWidgetModal);
+
+    document.querySelectorAll('.tile-widget-btn').forEach(btn => {
+      btn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        const wrapper = this.closest('.tile-wrapper');
+        if (!wrapper) return;
+        const containerName = (wrapper.querySelector('.container-name')?.textContent || '').trim();
+        const widgetGrid = wrapper.querySelector('.drawer-widget-grid');
+        showWidgetModal(containerName, widgetGrid);
+      });
+    });
+  }
+
   /* ── Changelog "What's new" modal ───────────────────── */
   function initChangelogModal() {
     const modal   = document.getElementById('changelog-modal');
@@ -338,6 +492,7 @@
     function dismiss() {
       localStorage.setItem(STORAGE_KEY, currentVersion);
       modal.classList.add('hidden');
+      secondsSinceRefresh = 0;
       document.removeEventListener('keydown', onEsc);
     }
 
@@ -361,7 +516,6 @@
         .then(r => r.json())
         .then(data => {
           if (!data.sections || data.sections.length === 0) {
-            // Downgrade case or already current — silently update.
             localStorage.setItem(STORAGE_KEY, currentVersion);
           } else {
             showModal(data.sections);
@@ -370,6 +524,9 @@
         .catch(() => {});
     }
   }
+
+  /* Expose popover API for pages with inline script (e.g. edit_entry.html) */
+  window.showDeletePopover = showDeletePopover;
 
   /* ── Bootstrap ───────────────────────────────────────── */
   document.addEventListener('DOMContentLoaded', function () {
@@ -386,8 +543,11 @@
       initDrawers();
       initToolsPopovers();
       initDrawerDelete();
+      initTileTrash();
+      initWidgetModal();
     } else if (view === 'dashboard') {
       initDashboardGroupCollapse();
+      initDashboardTrash();
     }
     // compact has no extra init beyond refresh/filter/view-controls
   });

--- a/templates/base.html
+++ b/templates/base.html
@@ -50,6 +50,8 @@
   </div>
 
   {% include 'partials/changelog_modal.html' %}
+  {% include 'partials/delete_popover.html' %}
+  {% include 'partials/widget_modal.html' %}
   {% block extra_scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -228,16 +228,30 @@
               </td>
             {% endif %}
 
-            {# Actions column — pencil icon edit + static lock indicator #}
+            {# Actions column — pencil icon edit + trash/lock #}
             <td class="px-3 py-2">
-              <a href="{{ url_for('dashboard.edit_entry', id=entry.id, ref=request.full_path) }}"
-                 class="inline-flex items-center justify-center border border-yellow-400 text-yellow-300 rounded p-1 hover:bg-yellow-400 hover:text-black transition"
-                 title="Edit">
-                <i class="ti ti-edit" aria-hidden="true" style="font-size:14px;"></i>
-              </a>
-              {% if entry.is_static %}
-                <span title="Static entry — API updates blocked" class="ml-2">🔒</span>
-              {% endif %}
+              <div class="inline-flex items-center gap-1">
+                <a href="{{ url_for('dashboard.edit_entry', id=entry.id, ref=request.full_path) }}"
+                   class="inline-flex items-center justify-center border border-yellow-400 text-yellow-300 rounded p-1 hover:bg-yellow-400 hover:text-black transition"
+                   title="Edit">
+                  <i class="ti ti-edit" aria-hidden="true" style="font-size:14px;"></i>
+                </a>
+                {% if entry.is_static %}
+                  <span class="inline-flex items-center justify-center text-gray-500 p-1"
+                        title="Locked — delete from edit page"
+                        style="cursor: default; font-size: 16px;">
+                    <i class="ti ti-lock" aria-hidden="true"></i>
+                  </span>
+                {% else %}
+                  <button class="row-trash-btn inline-flex items-center justify-center text-gray-500 hover:text-red-500 p-1 transition"
+                          data-entry-id="{{ entry.id }}"
+                          data-container-name="{{ entry.container_name }}"
+                          title="Delete {{ entry.container_name }}"
+                          style="background: none; border: none; cursor: pointer; font-size: 16px;">
+                    <i class="ti ti-trash" aria-hidden="true"></i>
+                  </button>
+                {% endif %}
+              </div>
             </td>
           </tr>
           {% endfor %}

--- a/templates/edit_entry.html
+++ b/templates/edit_entry.html
@@ -7,7 +7,9 @@
     <form action="{{ url_for('dashboard.edit_entry', id=entry.id, ref=ref) }}" method="POST">
       <input type="hidden" name="force_update_icon" value="true">
 
-      <div class="space-y-5">
+      {# ── Identity ────────────────────────────────────────── #}
+      <h3 class="edit-section-heading">Identity</h3>
+      <div class="edit-section-fields">
         <div>
           <label for="host" class="block text-sm font-medium text-dashboard-secondary mb-1">Host</label>
           <input type="text" name="host" id="host" class="form-input" value="{{ entry.host }}">
@@ -17,36 +19,33 @@
           <label for="application" class="block text-sm font-medium text-dashboard-secondary mb-1">Application (Container Name)</label>
           <input type="text" name="container_name" id="application" class="form-input" value="{{ entry.container_name }}">
         </div>
+      </div>
 
-        {# URL source provenance (v0.6.0). Render a small badge next to
-           each URL field telling the operator which actor last set it.
-           "Edit" + "Save" clears the badge to "ui_edit". Clearing the
-           field resets source to NULL so synthesis can re-fill. #}
-        {% macro url_source_badge(source) %}
-          {% if source == 'ui_edit' %}
-            <span class="text-xs text-blue-300 bg-blue-900/40 border border-blue-700 rounded px-2 py-0.5">Edited in UI</span>
-          {% elif source == 'explicit_label' %}
-            <span class="text-xs text-amber-200 bg-amber-900/40 border border-amber-700 rounded px-2 py-0.5">Explicit label</span>
-          {% elif source == 'synthesized' %}
-            <span class="text-xs text-emerald-200 bg-emerald-900/40 border border-emerald-700 rounded px-2 py-0.5">Synthesized</span>
-          {% endif %}
-        {% endmacro %}
+      {# URL source provenance badge macro #}
+      {% macro url_source_badge(source) %}
+        {% if source == 'ui_edit' %}
+          <span class="text-xs text-blue-300 bg-blue-900/40 border border-blue-700 rounded px-2 py-0.5">Edited in UI</span>
+        {% elif source == 'explicit_label' %}
+          <span class="text-xs text-amber-200 bg-amber-900/40 border border-amber-700 rounded px-2 py-0.5">Explicit label</span>
+        {% elif source == 'synthesized' %}
+          <span class="text-xs text-emerald-200 bg-emerald-900/40 border border-emerald-700 rounded px-2 py-0.5">Synthesized</span>
+        {% endif %}
+      {% endmacro %}
 
+      {# ── URLs & Health ────────────────────────────────────── #}
+      <h3 class="edit-section-heading">URLs &amp; Health</h3>
+      <div class="edit-section-fields">
         <div>
           <label for="internal_url" class="block text-sm font-medium text-dashboard-secondary mb-1">
             Internal URL
             {{ url_source_badge(entry.internalurl_source) }}
           </label>
-          <div class="flex items-center space-x-3">
-            <input type="url" name="internalurl" id="internal_url" class="form-input flex-grow" value="{{ entry.internalurl or '' }}">
-            <div class="flex items-center">
-              <input type="checkbox" name="internal_health_check_enabled" id="internal_health_check" class="form-checkbox h-5 w-5" {% if entry.internal_health_check_enabled %}checked{% endif %}>
-              <label for="internal_health_check" class="ml-2 text-sm text-dashboard-secondary">Health Check</label>
-            </div>
+          <input type="url" name="internalurl" id="internal_url" class="form-input" value="{{ entry.internalurl or '' }}">
+          <div class="flex items-center mt-1.5">
+            <input type="checkbox" name="internal_health_check_enabled" id="internal_health_check" class="form-checkbox h-4 w-4" {% if entry.internal_health_check_enabled %}checked{% endif %}>
+            <label for="internal_health_check" class="ml-2 text-sm text-dashboard-secondary">Health check enabled</label>
           </div>
-          <p class="mt-1 text-xs text-dashboard-secondary">
-            Clearing this field resets provenance and re-allows synthesis from exposure observations.
-          </p>
+          <p class="edit-helper">Clearing this field resets provenance and re-allows synthesis from exposure observations.</p>
         </div>
 
         <div>
@@ -54,24 +53,25 @@
             External URL
             {{ url_source_badge(entry.externalurl_source) }}
           </label>
-          <div class="flex items-center space-x-3">
-            <input type="url" name="externalurl" id="external_url" class="form-input flex-grow" value="{{ entry.externalurl or '' }}">
-            <div class="flex items-center">
-              <input type="checkbox" name="external_health_check_enabled" id="external_health_check" class="form-checkbox h-5 w-5" {% if entry.external_health_check_enabled %}checked{% endif %}>
-              <label for="external_health_check" class="ml-2 text-sm text-dashboard-secondary">Health Check</label>
-            </div>
+          <input type="url" name="externalurl" id="external_url" class="form-input" value="{{ entry.externalurl or '' }}">
+          <div class="flex items-center mt-1.5">
+            <input type="checkbox" name="external_health_check_enabled" id="external_health_check" class="form-checkbox h-4 w-4" {% if entry.external_health_check_enabled %}checked{% endif %}>
+            <label for="external_health_check" class="ml-2 text-sm text-dashboard-secondary">Health check enabled</label>
           </div>
         </div>
+      </div>
 
+      {# ── Grouping & Display ───────────────────────────────── #}
+      <h3 class="edit-section-heading">Grouping &amp; Display</h3>
+      <div class="edit-section-fields">
         <div>
-          <label class="block text-sm font-medium text-dashboard-secondary mb-1">Group</label>
+          <label class="block text-sm font-medium text-dashboard-secondary mb-1.5">Group</label>
 
-          <div class="flex items-center space-x-3 mb-2">
-            <input type="radio" id="select_existing" name="group_mode" value="existing" checked onclick="toggleGroupMode()" class="form-radio text-blue-600">
-            <label for="select_existing" class="text-sm text-gray-300">Select Existing</label>
-
-            <input type="radio" id="add_new" name="group_mode" value="new" onclick="toggleGroupMode()" class="form-radio text-blue-600 ml-4">
-            <label for="add_new" class="text-sm text-gray-300">Add New</label>
+          <div class="group-mode-tabs mb-2">
+            <input type="radio" id="select_existing" name="group_mode" value="existing" checked onclick="toggleGroupMode()" class="sr-only">
+            <label for="select_existing" class="group-tab">Select Existing</label>
+            <input type="radio" id="add_new" name="group_mode" value="new" onclick="toggleGroupMode()" class="sr-only">
+            <label for="add_new" class="group-tab">Add New</label>
           </div>
 
           <select name="group_id_existing" id="group_id_existing" class="form-input">
@@ -89,22 +89,25 @@
         <div>
           <label for="sort_priority" class="block text-sm font-medium text-dashboard-secondary mb-1">Sort Priority</label>
           <input type="number" name="sort_priority" id="sort_priority" class="form-input" value="{{ entry.sort_priority if entry.sort_priority is not none else '' }}">
-          <p class="mt-1 text-xs text-dashboard-secondary">Optional. Lower numbers show up higher in group listings.</p>
+          <p class="edit-helper">Optional. Lower numbers show up higher in group listings.</p>
         </div>
 
         <div>
           <label for="icon_image" class="block text-sm font-medium text-dashboard-secondary mb-1">Icon Image</label>
           <input type="text" name="image_icon" id="icon_image" class="form-input" value="{{ entry.image_icon or '' }}">
-          <p class="mt-1 text-xs text-dashboard-secondary">Enter the filename of the SVG icon (e.g., service.svg). Will try to match automatically from application above.</p>
+          <p class="edit-helper">Filename of the SVG icon (e.g., service.svg). Will try to match automatically from the application name above.</p>
         </div>
 
         <div class="flex items-center">
-          <input type="checkbox" name="is_static" id="locked" class="form-checkbox h-5 w-5" {% if entry.is_static %}checked{% endif %}>
+          <input type="checkbox" name="is_static" id="locked" class="form-checkbox h-4 w-4" {% if entry.is_static %}checked{% endif %}>
           <label for="locked" class="ml-2 text-sm text-dashboard-secondary">Locked (Static Entry)</label>
         </div>
+      </div>
 
-        <div class="pt-6">
-          <h2 class="text-lg font-semibold text-dashboard-primary mb-2">Widget Settings</h2>
+      {# ── Widget ───────────────────────────────────────────── #}
+      <h3 class="edit-section-heading">Widget</h3>
+      <div class="edit-section-fields">
+        <div>
           <label for="widget_name" class="block text-sm font-medium text-dashboard-secondary mb-1">Select Widget</label>
           <select name="widget_name" id="widget_name" class="form-input">
             <option value="none" {% if not selected_widget %}selected{% endif %}>None</option>
@@ -112,29 +115,38 @@
             <option value="{{ name }}" {% if selected_widget and selected_widget.widget_name == name %}selected{% endif %}>{{ name|capitalize }}</option>
             {% endfor %}
           </select>
-
-          <div class="mt-4">
-            <label for="widget_url" class="block text-sm font-medium text-dashboard-secondary mb-1">API URL</label>
-            <input type="text" name="widget_url" id="widget_url" class="form-input" value="{{ selected_widget.widget_url if selected_widget else '' }}">
-          </div>
-
-          <div class="mt-4">
-            <label for="widget_api_key" class="block text-sm font-medium text-dashboard-secondary mb-1">API Key</label>
-            <input type="text" name="widget_api_key" id="widget_api_key" class="form-input" value="{{ selected_widget.widget_api_key if selected_widget else '' }}">
-          </div>
-
-          <div class="mt-4" id="widget_fields_container"></div>
         </div>
+
+        <div>
+          <label for="widget_url" class="block text-sm font-medium text-dashboard-secondary mb-1">API URL</label>
+          <input type="text" name="widget_url" id="widget_url" class="form-input" value="{{ selected_widget.widget_url if selected_widget else '' }}">
+        </div>
+
+        <div>
+          <label for="widget_api_key" class="block text-sm font-medium text-dashboard-secondary mb-1">API Key</label>
+          <input type="text" name="widget_api_key" id="widget_api_key" class="form-input" value="{{ selected_widget.widget_api_key if selected_widget else '' }}">
+        </div>
+
+        <div id="widget_fields_container"></div>
       </div>
 
-      <div class="flex justify-end space-x-4 mt-8">
+      {# ── Form actions ─────────────────────────────────────── #}
+      <div class="flex flex-wrap items-center gap-3 mt-8">
         <button type="submit" class="btn-primary px-6 py-2.5 rounded-lg font-medium text-sm">Update Entry</button>
         <button type="button" onclick="window.history.back();" class="btn-secondary px-6 py-2.5 rounded-lg font-medium text-sm">Cancel</button>
+        <button type="button" id="edit-delete-btn"
+                class="edit-delete-btn ml-auto"
+                data-entry-id="{{ entry.id }}"
+                data-container-name="{{ entry.container_name }}"
+                data-redirect="{{ ref }}">
+          <i class="ti ti-trash" aria-hidden="true"></i> Delete
+        </button>
       </div>
     </form>
 
     <hr class="my-10 border-dashboard-accent">
 
+    {# ── Reported by notifier (read-only) ─────────────────── #}
     <div class="bg-dashboard-info-box rounded-lg p-6">
       <h2 class="text-lg font-semibold text-dashboard-primary mb-1">Reported by notifier</h2>
       <p class="text-xs text-dashboard-secondary mb-4">
@@ -213,22 +225,6 @@
         {% endif %}
       </div>
     </div>
-
-    <hr class="my-10 border-dashboard-accent">
-
-    <div class="bg-dashboard-info-box rounded-lg p-6">
-      <h2 class="text-lg font-semibold text-red-400 mb-3">Danger Zone</h2>
-      <p class="text-sm text-dashboard-secondary mb-2">Deleting this entry is permanent and cannot be undone.</p>
-      <form action="{{ url_for('dashboard.edit_entry', id=entry.id, ref=ref) }}" method="POST">
-        <label for="delete_confirmation" class="block text-sm font-medium text-dashboard-secondary mb-1">
-          Type <strong>{{ entry.container_name }}</strong> to confirm deletion:
-        </label>
-        <div class="flex flex-col sm:flex-row sm:items-center sm:space-x-4">
-          <input type="text" name="delete_confirmation" id="delete_confirmation" placeholder="Type container name to confirm" class="form-input w-full sm:w-auto">
-          <button type="submit" name="delete" value="true" class="btn-secondary bg-red-600 hover:bg-red-700 w-full sm:w-auto px-6 py-2.5 rounded-lg font-medium text-sm">Delete Entry</button>
-        </div>
-      </form>
-    </div>
   </div>
 </div>
 {% endblock %}
@@ -270,7 +266,7 @@
             container.appendChild(label);
           });
         })
-        .catch(err => console.error("❌ Error loading widget config:", err));
+        .catch(err => console.error('Error loading widget config:', err));
     }
 
     if (widgetSelect) {
@@ -295,7 +291,23 @@
       selectExisting.addEventListener('change', toggleGroupMode);
       addNew.addEventListener('change', toggleGroupMode);
     }
+
+    // === Edit-page Delete button → popover ===
+    const deleteBtn = document.getElementById('edit-delete-btn');
+    if (deleteBtn) {
+      deleteBtn.addEventListener('click', function () {
+        const entryId       = this.dataset.entryId;
+        const containerName = this.dataset.containerName;
+        const redirectUrl   = this.dataset.redirect || '/';
+        if (typeof showDeletePopover === 'function') {
+          showDeletePopover(this, containerName, () => {
+            fetch(`/api/v1/entries/${entryId}/delete`, { method: 'POST' })
+              .then(r => { if (r.ok) window.location.href = redirectUrl; })
+              .catch(() => alert('Delete failed. Please try again.'));
+          });
+        }
+      });
+    }
   });
 </script>
 {% endblock %}
-

--- a/templates/partials/delete_popover.html
+++ b/templates/partials/delete_popover.html
@@ -1,0 +1,9 @@
+<div id="delete-popover" class="delete-popover hidden" role="dialog" aria-modal="false">
+  <div class="delete-popover-message">
+    Delete <strong class="delete-popover-target"></strong>?
+  </div>
+  <div class="delete-popover-actions">
+    <button class="delete-popover-cancel">Cancel</button>
+    <button class="delete-popover-confirm">Confirm</button>
+  </div>
+</div>

--- a/templates/partials/widget_modal.html
+++ b/templates/partials/widget_modal.html
@@ -1,0 +1,12 @@
+<div id="widget-modal" class="widget-modal hidden" role="dialog" aria-modal="true" aria-labelledby="widget-modal-title">
+  <div class="widget-modal-backdrop"></div>
+  <div class="widget-modal-panel">
+    <div class="widget-modal-header">
+      <h2 id="widget-modal-title" class="widget-modal-title"></h2>
+      <button class="widget-modal-close" aria-label="Close">&times;</button>
+    </div>
+    <div class="widget-modal-body" id="widget-modal-content">
+      <!-- populated by JS -->
+    </div>
+  </div>
+</div>

--- a/templates/tiled_dash.html
+++ b/templates/tiled_dash.html
@@ -176,9 +176,10 @@
 
                                     {# Widget indicator #}
                                     {% if entry.widget_id %}
-                                        <span class="status-icon status-icon-blue" title="Widget data — click chevron to expand">
+                                        <button class="status-icon status-icon-blue tile-widget-btn"
+                                                title="View widget data">
                                             <i class="ti ti-chart-line" aria-hidden="true"></i>
-                                        </span>
+                                        </button>
                                     {% endif %}
                                 </div>{# /tile-icon-row-status #}
 
@@ -201,6 +202,22 @@
                                        onclick="event.stopPropagation()">
                                         <i class="ti ti-edit" aria-hidden="true"></i>
                                     </a>
+
+                                    {# Trash / lock icon #}
+                                    {% if entry.is_static %}
+                                        <span class="status-icon status-icon-muted"
+                                              title="Locked — delete from edit page"
+                                              style="cursor: default;">
+                                            <i class="ti ti-lock" aria-hidden="true"></i>
+                                        </span>
+                                    {% else %}
+                                        <button class="status-icon status-icon-trash tile-trash-btn"
+                                                data-entry-id="{{ entry.id }}"
+                                                data-container-name="{{ entry.container_name }}"
+                                                title="Delete {{ entry.container_name }}">
+                                            <i class="ti ti-trash" aria-hidden="true"></i>
+                                        </button>
+                                    {% endif %}
 
                                     {# Expand chevron #}
                                     <button class="tile-chevron"
@@ -392,12 +409,13 @@
                                     <i class="ti ti-edit" aria-hidden="true"></i> Edit
                                 </a>
 
+                                {% if not entry.is_static %}
                                 <button class="drawer-btn drawer-btn-delete"
                                         data-entry-id="{{ entry.id }}"
-                                        data-container-name="{{ entry.container_name }}"
-                                        data-is-static="{{ 'true' if entry.is_static else 'false' }}">
+                                        data-container-name="{{ entry.container_name }}">
                                     <i class="ti ti-trash" aria-hidden="true"></i> Delete
                                 </button>
+                                {% endif %}
 
                                 {% if _has_dozzle %}
                                 <div class="drawer-tools-wrap">


### PR DESCRIPTION
## Summary

Third and final release in the "UI overhaul, part 2" arc. Five pieces of
work, all landing together:

- **Universal delete popover.** New inline popover replaces the old
  `confirm()`/`prompt()` dialogs and the typed-name Danger Zone form. All
  delete entry points (drawer button, tile trash icon, row trash icon, edit
  page button) use the same component. Backed by a new JSON endpoint
  `POST /api/v1/entries/<id>/delete` so tile/row deletes don't require a
  full page reload.

- **Trash + lock icons on Tiled tiles and Dashboard rows.** Dynamic entries
  get a trash icon in the action row (muted by default, red on hover). Static
  (Locked) entries get a lock icon in the same slot — passive, non-clickable,
  signals "delete from edit page only." Replaces the 🔒 emoji on Dashboard
  rows. Drawer Delete button hidden for static entries.

- **Edit page form polish.** Four section headings (Identity / URLs & Health /
  Grouping & Display / Widget), tighter input padding and border-radius, URL
  fields now group their health-check checkbox directly below the input,
  helper text muted and italicized, group selector replaced with a tab-style
  toggle (pure CSS, underlying radios unchanged so `toggleGroupMode` JS is
  untouched). Danger Zone section removed; single Delete button at the bottom
  uses the new popover.

- **Widget data modal.** Chart icon on Tiled tiles is now a `<button>`. Click
  opens a modal populated from the already-server-rendered widget cards inside
  the tile's (hidden) drawer — no new API endpoint, no new template rendering.
  Responsive card grid: 3-col desktop → 2-col ≤480px → 1-col ≤360px.

- **Auto-refresh pauses while interacting.** New `isInteracting()` checks for
  any open tile drawer, widget modal, delete popover, or changelog modal. While
  true, the refresh tick skips the reload and shows "Refresh paused (drawer
  open)." Timer resets to 0 on close so the next cycle starts fresh.